### PR TITLE
Upgrade setup-gradle to version 5

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -68,7 +68,7 @@ jobs:
         encodedString: ${{ secrets.KEYSTORE }}
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4
+      uses: gradle/actions/setup-gradle@v5
       with:
         develocity-injection-enabled: true
         develocity-plugin-version: '3.18.2'
@@ -176,7 +176,7 @@ jobs:
             ${{ runner.os }}-android-sdk-
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
         with:
           develocity-injection-enabled: true
           develocity-plugin-version: '3.18.2'


### PR DESCRIPTION
Upgrade gradle/actions/setup-gradle from v4 to v5 to use Node.js 24 runtime. This is a safe upgrade with no breaking changes to Gradle configuration, Develocity injection, or cache behavior.