### PR TITLE
Show allergens Fix issue #8 in BeerFestApp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Allergen information display in beer details view ([#8](https://github.com/richardthe3rd/BeerFestApp/issues/8))
+- Allergen abbreviations (using UK FSA standard) in beer list items
+- Filter by allergen functionality to hide beers containing specific allergens
+- AllergenHelper utility class for consistent allergen display across the app
+
 ### Fixed
 - Edge-to-edge display compatibility for Android 15+ (SDK 35) ([#60](https://github.com/richardthe3rd/BeerFestApp/issues/60), [#61](https://github.com/richardthe3rd/BeerFestApp/issues/61))
+- Fixed typo in JSON field name for allergens ("allegens" -> "allergens")
 
 ## [2025.11.0] - 2025-11-22
 

--- a/app/src/androidTest/java/ralcock/cbf/model/BeerListTest.java
+++ b/app/src/androidTest/java/ralcock/cbf/model/BeerListTest.java
@@ -50,12 +50,14 @@ public class BeerListTest {
                 eq(sortOrder),
                 eq(mild),
                 eq(EMPTY_SET),
+                eq(EMPTY_SET),
                 eq(EMPTY_SET)
         )).andReturn(Arrays.asList(aMild));
 
         expect(fBeers.allBeersList(
                 eq(sortOrder),
                 eq(best),
+                eq(EMPTY_SET),
                 eq(EMPTY_SET),
                 eq(EMPTY_SET)
         )).andReturn(Arrays.asList(aBest, anotherBest));
@@ -89,6 +91,7 @@ public class BeerListTest {
                 eq(sortOrder1),
                 eq(filterText),
                 eq(EMPTY_SET),
+                eq(EMPTY_SET),
                 eq(EMPTY_SET)
         )).andReturn(Arrays.asList(beer1, beer2, beer3));
 
@@ -96,6 +99,7 @@ public class BeerListTest {
         expect(fBeers.allBeersList(
                 eq(sortOrder2),
                 eq(filterText),
+                eq(EMPTY_SET),
                 eq(EMPTY_SET),
                 eq(EMPTY_SET)
         )).andReturn(Arrays.asList(beer2, beer1, beer3));
@@ -130,6 +134,7 @@ public class BeerListTest {
                 eq(sortOrder),
                 eq(filterText),
                 eq(stylesToHide),
+                eq(EMPTY_SET),
                 eq(EMPTY_SET)
         )).andReturn(Arrays.asList(new Beer()));
         replay(fBeers, fBreweries);

--- a/app/src/androidTest/java/ralcock/cbf/model/JsonBeerListTest.java
+++ b/app/src/androidTest/java/ralcock/cbf/model/JsonBeerListTest.java
@@ -18,6 +18,19 @@ public class JsonBeerListTest {
     private final Brewery fBrewery1 = new Brewery("1", "BREWERY_ONE", "BREWERY_ONE_NOTES");
     private final Brewery fBrewery2 = new Brewery("2", "BREWERY_TWO", "BREWERY_TWO_NOTES");
 
+    // Expected beer for one_beer.json (has gluten + sulphites)
+    private final Beer fOneBeerExpected = new BeerBuilder()
+            .withFestivalId("1")
+            .called("BEER_ONE")
+            .withABV(1.1f)
+            .withDescription("BEER_ONE_NOTES")
+            .withStyle("STYLE1")
+            .withStatus("BEER_ONE_STATUS")
+            .withAllergens("gluten, sulphites")
+            .fromBrewery(fBrewery1)
+            .build();
+
+    // Expected beer for two_breweries_three_beers.json (has only gluten)
     private final Beer fBrewery1Beer1 = new BeerBuilder()
             .withFestivalId("1")
             .called("BEER_ONE")
@@ -25,6 +38,7 @@ public class JsonBeerListTest {
             .withDescription("BEER_ONE_NOTES")
             .withStyle("STYLE1")
             .withStatus("BEER_ONE_STATUS")
+            .withAllergens("gluten")
             .fromBrewery(fBrewery1)
             .build();
 
@@ -35,6 +49,7 @@ public class JsonBeerListTest {
             .withDescription("BEER_TWO_NOTES")
             .withStyle("STYLE2")
             .withStatus("BEER_TWO_STATUS")
+            .withAllergens("sulphites")
             .fromBrewery(fBrewery2)
             .build();
 
@@ -45,6 +60,7 @@ public class JsonBeerListTest {
             .withDescription("BEER_THREE_NOTES")
             .withStyle("STYLE3")
             .withStatus("BEER_THREE_STATUS")
+            .withAllergens("")
             .fromBrewery(fBrewery2)
             .build();
 
@@ -59,7 +75,7 @@ public class JsonBeerListTest {
     @Test
     public void testLoadBeers() throws JSONException {
         InputStream inputStream = JsonBeerListTest.class.getResourceAsStream("/ralcock/cbf/model/one_beer.json");
-        final Beer expectedBeer = fBrewery1Beer1;
+        final Beer expectedBeer = fOneBeerExpected;
         JsonBeerList jsonBeerList = new JsonBeerList(convertStreamToString(inputStream));
         for (Beer beer : jsonBeerList) {
             assertEquals(expectedBeer, beer);

--- a/app/src/androidTest/java/ralcock/cbf/model/dao/BeersImplTest.java
+++ b/app/src/androidTest/java/ralcock/cbf/model/dao/BeersImplTest.java
@@ -81,9 +81,10 @@ public class BeersImplTest {
         }
     }
 
-    private List<Beer> doQuery(SortOrder sortOrder, CharSequence filterText, Set<String> stylesToHide) throws SQLException {
+    private List<Beer> doQuery(final SortOrder sortOrder, final CharSequence filterText, final Set<String> stylesToHide) throws SQLException {
         Set<String> noAllergensToHide = Collections.emptySet();
-        return fBeers.allBeersList(sortOrder, filterText, stylesToHide, noAllergensToHide, stylesToHide);
+        Set<String> noStatusToHide = Collections.emptySet();
+        return fBeers.allBeersList(sortOrder, filterText, stylesToHide, noAllergensToHide, noStatusToHide);
     }
 
     @Test

--- a/app/src/androidTest/java/ralcock/cbf/model/dao/BeersImplTest.java
+++ b/app/src/androidTest/java/ralcock/cbf/model/dao/BeersImplTest.java
@@ -59,13 +59,13 @@ public class BeersImplTest {
         Brewery brewery2 = new Brewery("2", "Best Brewery", "");
         fBreweries.create(brewery2);
 
-        fBeer1 = new Beer("1", "A Mild", 1f, "description1", fStyle1, "status1", "cask", brewery);
+        fBeer1 = new Beer("1", "A Mild", 1f, "description1", fStyle1, "status1", "cask", "gluten", brewery);
         fBeers.create(fBeer1);
 
-        fBeer2 = new Beer("2", "A Best Bitter", 2f, "description2", fStyle2, "status2", "cask", brewery);
+        fBeer2 = new Beer("2", "A Best Bitter", 2f, "description2", fStyle2, "status2", "cask", "", brewery);
         fBeers.create(fBeer2);
 
-        fBeer3 = new Beer("3", "A Stout", 3f, "description3", fStyle2, "status3", "cask", brewery2);
+        fBeer3 = new Beer("3", "A Stout", 3f, "description3", fStyle2, "status3", "cask", "sulphites", brewery2);
         fBeers.create(fBeer3);
 
         assertEquals(3, fBeers.getNumberOfBeers());
@@ -82,7 +82,8 @@ public class BeersImplTest {
     }
 
     private List<Beer> doQuery(SortOrder sortOrder, CharSequence filterText, Set<String> stylesToHide) throws SQLException {
-        return fBeers.allBeersList(sortOrder, filterText, stylesToHide, stylesToHide);
+        Set<String> noAllergensToHide = Collections.emptySet();
+        return fBeers.allBeersList(sortOrder, filterText, stylesToHide, noAllergensToHide, stylesToHide);
     }
 
     @Test

--- a/app/src/androidTest/resources/ralcock/cbf/model/one_beer.json
+++ b/app/src/androidTest/resources/ralcock/cbf/model/one_beer.json
@@ -11,7 +11,11 @@
                     "style": "STYLE1",
                     "notes": "BEER_ONE_NOTES",
                     "abv": 1.1,
-                    "status_text": "BEER_ONE_STATUS"
+                    "status_text": "BEER_ONE_STATUS",
+                    "allergens": {
+                        "gluten": 1,
+                        "sulphites": 1
+                    }
                 }
             ]
         }

--- a/app/src/androidTest/resources/ralcock/cbf/model/two_breweries_three_beers.json
+++ b/app/src/androidTest/resources/ralcock/cbf/model/two_breweries_three_beers.json
@@ -11,7 +11,10 @@
                     "style": "STYLE1",
                     "notes": "BEER_ONE_NOTES",
                     "abv": 1.1,
-                    "status_text": "BEER_ONE_STATUS"
+                    "status_text": "BEER_ONE_STATUS",
+                    "allergens": {
+                        "gluten": 1
+                    }
                 }
             ]
         },
@@ -26,7 +29,10 @@
                     "style": "STYLE2",
                     "notes": "BEER_TWO_NOTES",
                     "abv": 2.2,
-                    "status_text": "BEER_TWO_STATUS"
+                    "status_text": "BEER_TWO_STATUS",
+                    "allergens": {
+                        "sulphites": 1
+                    }
                 },
                 {
                     "id": "3",
@@ -34,7 +40,8 @@
                     "style": "STYLE3",
                     "notes": "BEER_THREE_NOTES",
                     "abv": 3.3,
-                    "status_text": "BEER_THREE_STATUS"
+                    "status_text": "BEER_THREE_STATUS",
+                    "allergens": {}
                 }
             ]
         }

--- a/app/src/main/java/ralcock/cbf/AppPreferences.java
+++ b/app/src/main/java/ralcock/cbf/AppPreferences.java
@@ -27,6 +27,7 @@ public final class AppPreferences {
     private static final String NEXT_UPDATE_TIME_KEY = "lastUpdateTime";
     private static final String HIDE_UNAVAILABLE_KEY = "hideUnavailable";
     private static final String STYLES_TO_HIDE_KEY = "stylesToHide";
+    private static final String ALLERGENS_TO_HIDE_KEY = "allergensToHide";
     private static final String LAST_UPDATE_MD5_KEY = "lastUpdateMD5";
 
     private final Context fContext;
@@ -50,6 +51,14 @@ public final class AppPreferences {
 
     public Set<String> getStylesToHide() {
         return getPreference(STYLES_TO_HIDE_KEY, new HashSet<String>());
+    }
+
+    public void setAllergensToHide(Set<String> allergensToHide) {
+        setPreference(ALLERGENS_TO_HIDE_KEY, allergensToHide);
+    }
+
+    public Set<String> getAllergensToHide() {
+        return getPreference(ALLERGENS_TO_HIDE_KEY, new HashSet<String>());
     }
 
     public void setFilterText(String filterText) {
@@ -162,6 +171,7 @@ public final class AppPreferences {
                 getSortOrder(),
                 getFilterText(),
                 getStylesToHide(),
+                getAllergensToHide(),
                 getStatusToShow());
     }
 }

--- a/app/src/main/java/ralcock/cbf/CamBeerFestApplication.java
+++ b/app/src/main/java/ralcock/cbf/CamBeerFestApplication.java
@@ -39,6 +39,7 @@ import ralcock.cbf.service.UpdateTask;
 import ralcock.cbf.util.ExceptionReporter;
 import ralcock.cbf.view.AboutDialogFragment;
 import ralcock.cbf.view.BeerListFragmentPagerAdapter;
+import ralcock.cbf.view.FilterByAllergenDialogFragment;
 import ralcock.cbf.view.FilterByStyleDialogFragment;
 import ralcock.cbf.view.ListChangedListener;
 import ralcock.cbf.view.SortByDialogFragment;
@@ -262,6 +263,9 @@ public class CamBeerFestApplication extends AppCompatActivity {
         } else if (itemId == R.id.showOnlyStyle) {
             showFilterByStyleDialog();
             return true;
+        } else if (itemId == R.id.filterByAllergen) {
+            showFilterByAllergenDialog();
+            return true;
         } else if (itemId == R.id.hideUnavailable) {
             return true;
         } else if (itemId == R.id.visitFestivalWebsite) {
@@ -313,6 +317,12 @@ public class CamBeerFestApplication extends AppCompatActivity {
         newFragment.show(getSupportFragmentManager(), "filterByStyle");
     }
 
+    private void showFilterByAllergenDialog() {
+        final Set<String> allergensToHide = fAppPreferences.getAllergensToHide();
+        FilterByAllergenDialogFragment newFragment = FilterByAllergenDialogFragment.newInstance(allergensToHide);
+        newFragment.show(getSupportFragmentManager(), "filterByAllergen");
+    }
+
     public void notifyBeersChanged() {
         fireBeerListChanged();
     }
@@ -332,6 +342,10 @@ public class CamBeerFestApplication extends AppCompatActivity {
         filterByBeerStyle(stylesToHide);
     }
 
+    public void doDismissFilterByAllergenDialog(final Set<String> allergensToHide) {
+        filterByAllergen(allergensToHide);
+    }
+
     private void sortBy(SortOrder sortOrder) {
         fireSortByChanged(sortOrder);
         fAppPreferences.setSortOrder(sortOrder);
@@ -340,6 +354,11 @@ public class CamBeerFestApplication extends AppCompatActivity {
     private void filterByBeerStyle(Set<String> stylesToHide) {
         fireStylesToHideChanged(stylesToHide);
         fAppPreferences.setStylesToHide(stylesToHide);
+    }
+
+    private void filterByAllergen(Set<String> allergensToHide) {
+        fireAllergensToHideChanged(allergensToHide);
+        fAppPreferences.setAllergensToHide(allergensToHide);
     }
 
     public void addListChangedListener(final ListChangedListener listChangedListener) {
@@ -365,6 +384,12 @@ public class CamBeerFestApplication extends AppCompatActivity {
     private void fireStylesToHideChanged(final Set<String> stylesToHide) {
         for (ListChangedListener l : fListChangedListeners) {
             l.stylesToHideChanged(stylesToHide);
+        }
+    }
+
+    private void fireAllergensToHideChanged(final Set<String> allergensToHide) {
+        for (ListChangedListener l : fListChangedListeners) {
+            l.allergensToHideChanged(allergensToHide);
         }
     }
 

--- a/app/src/main/java/ralcock/cbf/model/BeerDatabaseHelper.java
+++ b/app/src/main/java/ralcock/cbf/model/BeerDatabaseHelper.java
@@ -16,7 +16,7 @@ import java.sql.SQLException;
 public final class BeerDatabaseHelper extends OrmLiteSqliteOpenHelper {
     public static final String DATABASE_NAME = "BEERS";
 
-    private static final int DB_VERSION = 32; // cbf2025
+    private static final int DB_VERSION = 33; // allergens support
 
     private Breweries fBreweries;
     private Beers fBeers;

--- a/app/src/main/java/ralcock/cbf/service/UpdateService.java
+++ b/app/src/main/java/ralcock/cbf/service/UpdateService.java
@@ -82,6 +82,8 @@ public class UpdateService extends OrmLiteBaseService<BeerDatabaseHelper> {
     @SuppressWarnings("deprecation")
     private void doUpdate(final boolean cleanUpdate) {
         Log.d(TAG, "doUpdate: cleanUpdate=" + cleanUpdate);
+        // Cache helper reference before async task starts to avoid accessing it after onDestroy
+        final BeerDatabaseHelper cachedHelper = getHelper();
         UpdateTask task = new UpdateTask() {
             @Override
             protected void onProgressUpdate(final Progress... values) {
@@ -128,7 +130,7 @@ public class UpdateService extends OrmLiteBaseService<BeerDatabaseHelper> {
 
             @Override
             BeerDatabaseHelper getDatabaseHelper() {
-                return getHelper();
+                return cachedHelper;
             }
 
             @Override

--- a/app/src/main/java/ralcock/cbf/view/AllergenHelper.java
+++ b/app/src/main/java/ralcock/cbf/view/AllergenHelper.java
@@ -1,0 +1,200 @@
+package ralcock.cbf.view;
+
+import android.content.Context;
+import ralcock.cbf.R;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Helper class for displaying allergen information using UK FSA standard 14 allergens.
+ * Provides abbreviations and display names for allergens commonly found in beer/beverages.
+ *
+ * @see <a href="https://www.food.gov.uk/business-guidance/allergen-guidance-for-food-businesses">FSA Allergen Guidance</a>
+ */
+public final class AllergenHelper {
+
+    // UK FSA 14 regulated allergens with abbreviations
+    private static final Map<String, String> ALLERGEN_ABBREVIATIONS = new LinkedHashMap<>();
+
+    static {
+        // Common beer/beverage allergens first
+        ALLERGEN_ABBREVIATIONS.put("gluten", "G");
+        ALLERGEN_ABBREVIATIONS.put("sulphites", "Su");
+        ALLERGEN_ABBREVIATIONS.put("sulphur dioxide", "Su");
+        ALLERGEN_ABBREVIATIONS.put("barley", "G");  // Contains gluten
+        ALLERGEN_ABBREVIATIONS.put("wheat", "G");   // Contains gluten
+        ALLERGEN_ABBREVIATIONS.put("oats", "G");    // Contains gluten
+        ALLERGEN_ABBREVIATIONS.put("rye", "G");     // Contains gluten
+
+        // Other UK regulated allergens
+        ALLERGEN_ABBREVIATIONS.put("celery", "Ce");
+        ALLERGEN_ABBREVIATIONS.put("crustaceans", "Cr");
+        ALLERGEN_ABBREVIATIONS.put("eggs", "E");
+        ALLERGEN_ABBREVIATIONS.put("fish", "F");
+        ALLERGEN_ABBREVIATIONS.put("lupin", "L");
+        ALLERGEN_ABBREVIATIONS.put("milk", "M");
+        ALLERGEN_ABBREVIATIONS.put("molluscs", "Mo");
+        ALLERGEN_ABBREVIATIONS.put("mustard", "Mu");
+        ALLERGEN_ABBREVIATIONS.put("peanuts", "P");
+        ALLERGEN_ABBREVIATIONS.put("sesame", "Se");
+        ALLERGEN_ABBREVIATIONS.put("soybeans", "So");
+        ALLERGEN_ABBREVIATIONS.put("soya", "So");
+        ALLERGEN_ABBREVIATIONS.put("tree nuts", "N");
+        ALLERGEN_ABBREVIATIONS.put("nuts", "N");
+    }
+
+    // Display names for allergen abbreviations (for legend/tooltip)
+    private static final Map<String, String> ABBREVIATION_NAMES = new LinkedHashMap<>();
+
+    static {
+        ABBREVIATION_NAMES.put("G", "Gluten");
+        ABBREVIATION_NAMES.put("Su", "Sulphites");
+        ABBREVIATION_NAMES.put("Ce", "Celery");
+        ABBREVIATION_NAMES.put("Cr", "Crustaceans");
+        ABBREVIATION_NAMES.put("E", "Eggs");
+        ABBREVIATION_NAMES.put("F", "Fish");
+        ABBREVIATION_NAMES.put("L", "Lupin");
+        ABBREVIATION_NAMES.put("M", "Milk");
+        ABBREVIATION_NAMES.put("Mo", "Molluscs");
+        ABBREVIATION_NAMES.put("Mu", "Mustard");
+        ABBREVIATION_NAMES.put("P", "Peanuts");
+        ABBREVIATION_NAMES.put("Se", "Sesame");
+        ABBREVIATION_NAMES.put("So", "Soybeans");
+        ABBREVIATION_NAMES.put("N", "Tree Nuts");
+    }
+
+    private AllergenHelper() {
+        // Utility class
+    }
+
+    /**
+     * Converts a comma-separated allergen string to abbreviations.
+     * E.g., "gluten, sulphites" becomes "G, Su"
+     */
+    public static String toAbbreviations(final String allergens) {
+        if (allergens == null || allergens.isEmpty()) {
+            return "";
+        }
+
+        StringBuilder result = new StringBuilder();
+        String[] parts = allergens.split(",");
+
+        for (String part : parts) {
+            String allergen = part.trim().toLowerCase();
+            String abbrev = ALLERGEN_ABBREVIATIONS.get(allergen);
+
+            if (abbrev != null) {
+                // Avoid duplicates (e.g., "gluten" and "barley" both map to "G")
+                if (result.indexOf(abbrev) < 0) {
+                    if (result.length() > 0) {
+                        result.append(" ");
+                    }
+                    result.append(abbrev);
+                }
+            } else if (!allergen.isEmpty()) {
+                // Unknown allergen - use first 2 chars uppercase
+                String unknown = allergen.length() >= 2
+                        ? allergen.substring(0, 1).toUpperCase() + allergen.substring(1, 2)
+                        : allergen.toUpperCase();
+                if (result.length() > 0) {
+                    result.append(" ");
+                }
+                result.append(unknown);
+            }
+        }
+        return result.toString();
+    }
+
+    /**
+     * Gets the full display text for allergens (for details view).
+     * Preserves the original allergen names from JSON as source of truth.
+     * E.g., "gluten, sulphites" becomes "Contains: Gluten, Sulphites"
+     */
+    public static String toDisplayText(final String allergens) {
+        if (allergens == null || allergens.isEmpty()) {
+            return "";
+        }
+
+        StringBuilder result = new StringBuilder();
+        String[] parts = allergens.split(",");
+
+        for (String part : parts) {
+            String allergen = part.trim();
+            if (!allergen.isEmpty()) {
+                if (result.length() > 0) {
+                    result.append(", ");
+                }
+                // Capitalize first letter, preserve rest as-is from JSON
+                result.append(allergen.substring(0, 1).toUpperCase())
+                      .append(allergen.substring(1));
+            }
+        }
+
+        if (result.length() > 0) {
+            return "Contains: " + result.toString();
+        }
+        return "";
+    }
+
+    /**
+     * Gets a legend explaining all abbreviations.
+     */
+    public static String getLegend() {
+        StringBuilder legend = new StringBuilder();
+        for (Map.Entry<String, String> entry : ABBREVIATION_NAMES.entrySet()) {
+            if (legend.length() > 0) {
+                legend.append("\n");
+            }
+            legend.append(entry.getKey()).append(" = ").append(entry.getValue());
+        }
+        return legend.toString();
+    }
+
+    /**
+     * Checks if the given allergens string contains a specific allergen.
+     */
+    public static boolean containsAllergen(final String allergens, final String allergenToCheck) {
+        if (allergens == null || allergens.isEmpty()) {
+            return false;
+        }
+        String[] parts = allergens.split(",");
+        String checkLower = allergenToCheck.toLowerCase();
+
+        for (String part : parts) {
+            String allergen = part.trim().toLowerCase();
+            if (allergen.equals(checkLower)) {
+                return true;
+            }
+            // Also check if it maps to the same abbreviation (e.g., "barley" -> gluten)
+            String abbrev = ALLERGEN_ABBREVIATIONS.get(allergen);
+            String checkAbbrev = ALLERGEN_ABBREVIATIONS.get(checkLower);
+            if (abbrev != null && abbrev.equals(checkAbbrev)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Gets all known allergen types for filtering purposes.
+     */
+    public static String[] getFilterableAllergens() {
+        return new String[]{
+                "Gluten",
+                "Sulphites",
+                "Milk",
+                "Eggs",
+                "Fish",
+                "Peanuts",
+                "Tree Nuts",
+                "Soybeans",
+                "Celery",
+                "Mustard",
+                "Sesame",
+                "Crustaceans",
+                "Molluscs",
+                "Lupin"
+        };
+    }
+}

--- a/app/src/main/java/ralcock/cbf/view/BeerDetailsFragment.java
+++ b/app/src/main/java/ralcock/cbf/view/BeerDetailsFragment.java
@@ -105,13 +105,13 @@ public class BeerDetailsFragment extends Fragment {
                 Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
     }
 
-    private void rateBeer(Beer beer, StarRating rating) {
+    private void rateBeer(final Beer beer, final StarRating rating) {
         beer.setNumberOfStars(rating);
         getHelper().getBeers().updateBeer(beer);
         displayBeer(beer);
     }
 
-    private void toggleBookmark(Beer beer) {
+    private void toggleBookmark(final Beer beer) {
         beer.setIsOnWishList(!beer.isIsOnWishList());
         getHelper().getBeers().updateBeer(beer);
         displayBeer(beer);

--- a/app/src/main/java/ralcock/cbf/view/BeerDetailsFragment.java
+++ b/app/src/main/java/ralcock/cbf/view/BeerDetailsFragment.java
@@ -19,6 +19,7 @@ import ralcock.cbf.model.Beer;
 import ralcock.cbf.model.BeerDatabaseHelper;
 import ralcock.cbf.model.StarRating;
 import java.util.Locale;
+import android.view.View;
 
 public class BeerDetailsFragment extends Fragment {
     private BeerDetailsView fBeerDetailsView;
@@ -59,6 +60,15 @@ public class BeerDetailsFragment extends Fragment {
         fBeerDetailsView.BreweryName.setText(beer.getBrewery().getName());
         fBeerDetailsView.BreweryDescription.setText(beer.getBrewery().getDescription());
         fBeerDetailsView.BeerDispense.setText(beer.getDispenseMethod());
+
+        // Display allergens
+        if (beer.hasAllergens()) {
+            String allergenText = AllergenHelper.toDisplayText(beer.getAllergens());
+            fBeerDetailsView.Allergens.setText(allergenText);
+            fBeerDetailsView.Allergens.setVisibility(View.VISIBLE);
+        } else {
+            fBeerDetailsView.Allergens.setVisibility(View.GONE);
+        }
 
         fBeerDetailsView.BeerRatingBar.setRating(beer.getRating());
 
@@ -120,6 +130,7 @@ public class BeerDetailsFragment extends Fragment {
         final TextView SearchOnline;
         final ImageView BookmarkImage;
         final TextView BeerDispense;
+        final TextView Allergens;
 
         private BeerDetailsView(final View view) {
             BeerNameAndAbv = (TextView) view.findViewById(R.id.detailsViewBeerNameAndAbv);
@@ -135,6 +146,7 @@ public class BeerDetailsFragment extends Fragment {
             SearchOnline.setMovementMethod(LinkMovementMethod.getInstance());
             BookmarkImage = (ImageView) view.findViewById(R.id.bookmark_image);
             BeerDispense = (TextView) view.findViewById(R.id.detailsViewBeerDispense);
+            Allergens = (TextView) view.findViewById(R.id.detailsViewAllergens);
         }
     }
 }

--- a/app/src/main/java/ralcock/cbf/view/BeerListAdapter.java
+++ b/app/src/main/java/ralcock/cbf/view/BeerListAdapter.java
@@ -61,6 +61,15 @@ public final class BeerListAdapter extends BaseAdapter implements Filterable {
         beerListItemView.BeerStyle.setText(beer.getStyle());
         beerListItemView.BeerDispense.setText(beer.getDispenseMethod());
 
+        // Display allergen abbreviations
+        if (beer.hasAllergens()) {
+            String allergenAbbrevs = AllergenHelper.toAbbreviations(beer.getAllergens());
+            beerListItemView.BeerAllergens.setText(allergenAbbrevs);
+            beerListItemView.BeerAllergens.setVisibility(View.VISIBLE);
+        } else {
+            beerListItemView.BeerAllergens.setVisibility(View.GONE);
+        }
+
         if (beer.isIsOnWishList()) {
             beerListItemView.BookmarkImage.setImageResource(R.drawable.ic_bookmark_black_48dp);
             beerListItemView.BeerName.setTypeface(beerListItemView.BeerName.getTypeface(),
@@ -111,6 +120,7 @@ public final class BeerListAdapter extends BaseAdapter implements Filterable {
         TextView BeerStatus;
         RatingBar BeerRatingBar;
         TextView BeerDispense;
+        TextView BeerAllergens;
         ImageView BookmarkImage;
 
         BeerListItemView(final View view) {
@@ -120,6 +130,7 @@ public final class BeerListAdapter extends BaseAdapter implements Filterable {
             BeerStyle = findTextViewById(view, R.id.beerStyle);
             BeerRatingBar = (RatingBar) view.findViewById(R.id.beerRatingBar);
             BeerDispense = findTextViewById(view, R.id.beerDispense);
+            BeerAllergens = findTextViewById(view, R.id.beerAllergens);
             BookmarkImage = (ImageView) view.findViewById(R.id.bookmark_image);
         }
 

--- a/app/src/main/java/ralcock/cbf/view/BeerListAdapter.java
+++ b/app/src/main/java/ralcock/cbf/view/BeerListAdapter.java
@@ -38,7 +38,7 @@ public final class BeerListAdapter extends BaseAdapter implements Filterable {
         return false;
     }
 
-    private View newView(ViewGroup viewGroup) {
+    private View newView(final ViewGroup viewGroup) {
         LayoutInflater layoutInflater = LayoutInflater.from(fContext);
         View view = layoutInflater.inflate(R.layout.beer_listitem, viewGroup, false);
         BeerListItemView beerListItemView = new BeerListItemView(view);
@@ -46,7 +46,7 @@ public final class BeerListAdapter extends BaseAdapter implements Filterable {
         return view;
     }
 
-    private void bindView(View view, final Beer beer) {
+    private void bindView(final View view, final Beer beer) {
         BeerListItemView beerListItemView = (BeerListItemView) view.getTag();
 
         Brewery brewery = beer.getBrewery();

--- a/app/src/main/java/ralcock/cbf/view/BeerListFragment.java
+++ b/app/src/main/java/ralcock/cbf/view/BeerListFragment.java
@@ -138,31 +138,37 @@ public abstract class BeerListFragment extends ListFragment implements ListChang
         getCamBeerFestApplication().removeListChangedListener(this);
     }
 
-    public void filterTextChanged(String filterText) {
+    @Override
+    public void filterTextChanged(final String filterText) {
         fBeerList.filterBy(filterText);
         fAdapter.notifyDataSetChanged();
     }
 
+    @Override
     public void sortOrderChanged(final SortOrder sortOrder) {
         fBeerList.sortBy(sortOrder);
         fAdapter.notifyDataSetChanged();
     }
 
+    @Override
     public void stylesToHideChanged(final Set<String> stylesToHide) {
         fBeerList.stylesToHide(stylesToHide);
         fAdapter.notifyDataSetChanged();
     }
 
+    @Override
     public void allergensToHideChanged(final Set<String> allergensToHide) {
         fBeerList.allergensToHide(allergensToHide);
         fAdapter.notifyDataSetChanged();
     }
 
+    @Override
     public void statusToShowChanged(final StatusToShow statusToShow) {
         fBeerList.setStatusToShow(statusToShow);
         fAdapter.notifyDataSetChanged();
     }
 
+    @Override
     public void beersChanged() {
         Log.i(TAG, "beersChanged: notifying ListAdapter of changed DataSet.");
         fBeerList.updateBeerList();

--- a/app/src/main/java/ralcock/cbf/view/BeerListFragment.java
+++ b/app/src/main/java/ralcock/cbf/view/BeerListFragment.java
@@ -153,6 +153,11 @@ public abstract class BeerListFragment extends ListFragment implements ListChang
         fAdapter.notifyDataSetChanged();
     }
 
+    public void allergensToHideChanged(final Set<String> allergensToHide) {
+        fBeerList.allergensToHide(allergensToHide);
+        fAdapter.notifyDataSetChanged();
+    }
+
     public void statusToShowChanged(final StatusToShow statusToShow) {
         fBeerList.setStatusToShow(statusToShow);
         fAdapter.notifyDataSetChanged();

--- a/app/src/main/java/ralcock/cbf/view/FilterByAllergenDialogFragment.java
+++ b/app/src/main/java/ralcock/cbf/view/FilterByAllergenDialogFragment.java
@@ -36,6 +36,9 @@ public class FilterByAllergenDialogFragment extends DialogFragment {
 
     private static Set<String> getStringSet(final Bundle arguments, final String key) {
         ArrayList<String> list = arguments.getStringArrayList(key);
+        if (list == null) {
+            return new HashSet<String>();
+        }
         return new HashSet<String>(list);
     }
 

--- a/app/src/main/java/ralcock/cbf/view/FilterByAllergenDialogFragment.java
+++ b/app/src/main/java/ralcock/cbf/view/FilterByAllergenDialogFragment.java
@@ -34,7 +34,7 @@ public class FilterByAllergenDialogFragment extends DialogFragment {
         args.putStringArrayList(key, list);
     }
 
-    private static Set<String> getStringSet(final Bundle arguments, String key) {
+    private static Set<String> getStringSet(final Bundle arguments, final String key) {
         ArrayList<String> list = arguments.getStringArrayList(key);
         return new HashSet<String>(list);
     }

--- a/app/src/main/java/ralcock/cbf/view/FilterByAllergenDialogFragment.java
+++ b/app/src/main/java/ralcock/cbf/view/FilterByAllergenDialogFragment.java
@@ -1,0 +1,98 @@
+package ralcock.cbf.view;
+
+import android.app.Dialog;
+import android.content.DialogInterface;
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
+import androidx.fragment.app.DialogFragment;
+
+import ralcock.cbf.CamBeerFestApplication;
+import ralcock.cbf.R;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Dialog for filtering beers by allergens to hide.
+ * Users select which allergens they want to exclude from the beer list.
+ */
+public class FilterByAllergenDialogFragment extends DialogFragment {
+
+    public static FilterByAllergenDialogFragment newInstance(final Set<String> allergensToHide) {
+        FilterByAllergenDialogFragment fragment = new FilterByAllergenDialogFragment();
+        Bundle args = new Bundle();
+        putStringSet(args, "allergensToHide", allergensToHide);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    private static void putStringSet(final Bundle args, final String key, final Set<String> stringSet) {
+        ArrayList<String> list = new ArrayList<String>(stringSet);
+        args.putStringArrayList(key, list);
+    }
+
+    private static Set<String> getStringSet(final Bundle arguments, String key) {
+        ArrayList<String> list = arguments.getStringArrayList(key);
+        return new HashSet<String>(list);
+    }
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(final Bundle savedInstanceState) {
+        Set<String> allergensToHide = getStringSet(getArguments(), "allergensToHide");
+
+        // Get all known allergens
+        final String[] allAllergens = AllergenHelper.getFilterableAllergens();
+        final boolean[] checkedItems = new boolean[allAllergens.length];
+
+        // Mark currently hidden allergens as checked
+        for (int i = 0; i < allAllergens.length; i++) {
+            checkedItems[i] = allergensToHide.contains(allAllergens[i].toLowerCase());
+        }
+
+        final Set<String> selectedAllergens = new HashSet<>(allergensToHide);
+
+        AlertDialog.Builder builder = new AlertDialog.Builder(requireActivity());
+        builder.setTitle(R.string.filter_allergen_dialog_title);
+
+        builder.setMultiChoiceItems(allAllergens, checkedItems,
+                new DialogInterface.OnMultiChoiceClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which, boolean isChecked) {
+                        String allergen = allAllergens[which].toLowerCase();
+                        if (isChecked) {
+                            selectedAllergens.add(allergen);
+                        } else {
+                            selectedAllergens.remove(allergen);
+                        }
+                    }
+                });
+
+        builder.setPositiveButton(R.string.OK, new DialogInterface.OnClickListener() {
+            public void onClick(final DialogInterface dialogInterface, final int i) {
+                dialogInterface.dismiss();
+                CamBeerFestApplication app = (CamBeerFestApplication) requireActivity();
+                app.doDismissFilterByAllergenDialog(selectedAllergens);
+            }
+        });
+
+        builder.setNegativeButton(R.string.CANCEL, new DialogInterface.OnClickListener() {
+            public void onClick(final DialogInterface dialogInterface, final int i) {
+                dialogInterface.dismiss();
+            }
+        });
+
+        builder.setNeutralButton(R.string.filter_allergen_clear_all, new DialogInterface.OnClickListener() {
+            public void onClick(final DialogInterface dialogInterface, final int i) {
+                dialogInterface.dismiss();
+                CamBeerFestApplication app = (CamBeerFestApplication) requireActivity();
+                app.doDismissFilterByAllergenDialog(new HashSet<String>());
+            }
+        });
+
+        return builder.create();
+    }
+}

--- a/app/src/main/java/ralcock/cbf/view/ListChangedListener.java
+++ b/app/src/main/java/ralcock/cbf/view/ListChangedListener.java
@@ -6,15 +6,15 @@ import ralcock.cbf.model.StatusToShow;
 import java.util.Set;
 
 public interface ListChangedListener {
-    void filterTextChanged(String filterText);
+    void filterTextChanged(final String filterText);
 
-    void sortOrderChanged(SortOrder sortOrder);
+    void sortOrderChanged(final SortOrder sortOrder);
 
-    void stylesToHideChanged(Set<String> stylesToHide);
+    void stylesToHideChanged(final Set<String> stylesToHide);
 
-    void allergensToHideChanged(Set<String> allergensToHide);
+    void allergensToHideChanged(final Set<String> allergensToHide);
 
-    void statusToShowChanged(StatusToShow statusToShow);
+    void statusToShowChanged(final StatusToShow statusToShow);
 
     void beersChanged();
 }

--- a/app/src/main/java/ralcock/cbf/view/ListChangedListener.java
+++ b/app/src/main/java/ralcock/cbf/view/ListChangedListener.java
@@ -12,6 +12,8 @@ public interface ListChangedListener {
 
     void stylesToHideChanged(Set<String> stylesToHide);
 
+    void allergensToHideChanged(Set<String> allergensToHide);
+
     void statusToShowChanged(StatusToShow statusToShow);
 
     void beersChanged();

--- a/app/src/main/res/layout/beer_details_fragment.xml
+++ b/app/src/main/res/layout/beer_details_fragment.xml
@@ -93,6 +93,18 @@
                 android:layout_alignParentRight="true"
                 />
             <TextView
+                android:text="[ALLERGENS]"
+                android:id="@+id/detailsViewAllergens"
+                android:padding="5dip"
+                android:textStyle="bold"
+                android:textColor="#D32F2F"
+                android:visibility="gone"
+                android:layout_height="wrap_content"
+                android:layout_width="wrap_content"
+                android:layout_below="@id/detailsViewBeerDescription"
+                android:layout_alignParentLeft="true"
+                />
+            <TextView
                 android:text="[BREWERY_NAME]"
                 android:id="@+id/detailsViewBreweryName"
                 android:textStyle="bold"
@@ -100,7 +112,7 @@
                 android:layout_height="wrap_content"
                 android:layout_width="wrap_content"
                 android:layout_alignParentLeft="true"
-                android:layout_below="@id/detailsViewBeerDescription"
+                android:layout_below="@id/detailsViewAllergens"
                 />
             <TextView
                 android:text="[BREWERY_DESCRIPTION]"

--- a/app/src/main/res/layout/beer_listitem.xml
+++ b/app/src/main/res/layout/beer_listitem.xml
@@ -63,6 +63,19 @@
             android:layout_alignLeft="@+id/beerDispense"
             />
 
+        <TextView
+            android:id="@+id/beerAllergens"
+            android:layout_height="wrap_content"
+            android:layout_width="wrap_content"
+            android:textSize="11sp"
+            android:textStyle="bold"
+            android:textColor="#D32F2F"
+            android:text="[ALLERGENS]"
+            android:visibility="gone"
+            android:layout_below="@+id/beerStatus"
+            android:layout_alignLeft="@+id/beerStatus"
+            />
+
         <ImageView
             android:id="@+id/bookmark_image"
             android:layout_height="wrap_content"

--- a/app/src/main/res/menu/list_options_menu.xml
+++ b/app/src/main/res/menu/list_options_menu.xml
@@ -26,6 +26,12 @@
             />
 
     <item
+            android:id="@+id/filterByAllergen"
+            android:title="@string/filter_allergen_label"
+            android:showAsAction="never"
+            />
+
+    <item
             android:id="@+id/hideUnavailable"
             android:visible="false"
             android:title="@string/show_only_available_label"

--- a/app/src/main/res/raw/ormlite_config.txt
+++ b/app/src/main/res/raw/ormlite_config.txt
@@ -62,6 +62,10 @@ indexName=beers_on_wish_list_idx
 fieldName=fUserComments
 columnName=user_comments
 # --field-end--
+# --field-start--
+fieldName=fAllergens
+columnName=allergens
+# --field-end--
 # --table-fields-end--
 # --table-end--
 #################################

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,6 +34,10 @@
     <string name="filter_available_all">Show all beers</string>
     <string name="filter_available_hide">Hide unavailable beers</string>
 
+    <string name="filter_allergen_label">Filter by allergen…</string>
+    <string name="filter_allergen_dialog_title">Hide beers containing:</string>
+    <string name="filter_allergen_clear_all">Clear All</string>
+
     <string name="OK">OK</string>
     <string name="CANCEL">Cancel</string>
     <string name="NoInternetConnection">Not updating beers as there is no internet connection.</string>

--- a/libraries/beers/src/main/java/ralcock/cbf/model/Beer.java
+++ b/libraries/beers/src/main/java/ralcock/cbf/model/Beer.java
@@ -23,6 +23,7 @@ public final class Beer implements Serializable {
     public static final String RATING_FIELD = "rating";
     public static final String ON_WISH_LIST_FIELD = "on_wish_list";
     public static final String USER_COMMENTS_FIELD = "user_comments";
+    public static final String ALLERGENS_FIELD = "allergens";
 
     @DatabaseField(columnName = "_id", generatedId = true)
     private long fId;
@@ -60,6 +61,9 @@ public final class Beer implements Serializable {
     @DatabaseField(columnName = USER_COMMENTS_FIELD)
     private String fUserComments;
 
+    @DatabaseField(columnName = ALLERGENS_FIELD)
+    private String fAllergens;
+
     @SuppressWarnings("UnusedDeclaration")
         // needed by ormlite
     Beer() {
@@ -72,6 +76,7 @@ public final class Beer implements Serializable {
                 final String style,
                 final String status,
                 final String dispense,
+                final String allergens,
                 final Brewery brewery) {
         fFestivalID = festivalId;
         fBrewery = brewery;
@@ -81,6 +86,7 @@ public final class Beer implements Serializable {
         fStyle = style;
         fStatus = status;
         fDispense = dispense;
+        fAllergens = allergens;
     }
 
     public String getFestivalID() {
@@ -159,6 +165,26 @@ public final class Beer implements Serializable {
         fDispense = dispense;
     }
 
+    public String getAllergens() {
+        return fAllergens;
+    }
+
+    public void setAllergens(final String allergens) {
+        fAllergens = allergens;
+    }
+
+    public boolean hasAllergens() {
+        return fAllergens != null && !fAllergens.isEmpty();
+    }
+
+    public boolean containsAllergen(final String allergen) {
+        if (fAllergens == null || fAllergens.isEmpty()) {
+            return false;
+        }
+        String lowerAllergens = fAllergens.toLowerCase();
+        return lowerAllergens.contains(allergen.toLowerCase());
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;
@@ -178,6 +204,7 @@ public final class Beer implements Serializable {
         if (fDispense != null ? !fDispense.equals(beer.fDispense) : beer.fDispense != null) return false;
         if (fUserComments != null ? !fUserComments.equals(beer.fUserComments) : beer.fUserComments != null)
             return false;
+        if (fAllergens != null ? !fAllergens.equals(beer.fAllergens) : beer.fAllergens != null) return false;
 
         return true;
     }
@@ -195,6 +222,7 @@ public final class Beer implements Serializable {
         result = 31 * result + (fDispense != null ? fDispense.hashCode() : 0);
         result = 31 * result + (fIsOnWishList ? 1 : 0);
         result = 31 * result + (fUserComments != null ? fUserComments.hashCode() : 0);
+        result = 31 * result + (fAllergens != null ? fAllergens.hashCode() : 0);
         return result;
     }
 
@@ -214,6 +242,7 @@ public final class Beer implements Serializable {
         sb.append(", fDispense='").append(fDispense).append('\'');
         sb.append(", fIsOnWishList=").append(fIsOnWishList);
         sb.append(", fUserComments='").append(fUserComments).append('\'');
+        sb.append(", fAllergens='").append(fAllergens).append('\'');
         sb.append('}');
         return sb.toString();
     }

--- a/libraries/beers/src/main/java/ralcock/cbf/model/BeerBuilder.java
+++ b/libraries/beers/src/main/java/ralcock/cbf/model/BeerBuilder.java
@@ -8,6 +8,7 @@ public class BeerBuilder {
     private String fStyle = "";
     private String fStatus = "";
     private String fDispense = "";
+    private String fAllergens = "";
     private Brewery fBrewery = null;
 
     public static BeerBuilder aBeer() {
@@ -49,13 +50,18 @@ public class BeerBuilder {
         return this;
     }
 
+    public BeerBuilder withAllergens(String allergens) {
+        fAllergens = allergens;
+        return this;
+    }
+
     public BeerBuilder fromBrewery(Brewery brewery) {
         fBrewery = brewery;
         return this;
     }
 
     public Beer build() {
-        return new Beer(fFestivalId, fName, fAbv, fDescription, fStyle, fStatus, fDispense, fBrewery);
+        return new Beer(fFestivalId, fName, fAbv, fDescription, fStyle, fStatus, fDispense, fAllergens, fBrewery);
     }
 
     public BeerBuilder from(final BreweryBuilder breweryBuilder) {

--- a/libraries/beers/src/main/java/ralcock/cbf/model/BeerList.java
+++ b/libraries/beers/src/main/java/ralcock/cbf/model/BeerList.java
@@ -29,9 +29,22 @@ public class BeerList {
             StatusToShow = statusToShow;
         }
 
+        public Config(final SortOrder sortOrder,
+                      final CharSequence searchText,
+                      final Set<String> stylesToHide,
+                      final Set<String> allergensToHide,
+                      final StatusToShow statusToShow) {
+            SortOrder = sortOrder;
+            SearchText = searchText;
+            StylesToHide = stylesToHide;
+            AllergensToHide = allergensToHide;
+            StatusToShow = statusToShow;
+        }
+
         public SortOrder SortOrder = ralcock.cbf.model.SortOrder.BREWERY_NAME_DESC;
         public CharSequence SearchText = "";
         public Set<String> StylesToHide = Collections.emptySet();
+        public Set<String> AllergensToHide = Collections.emptySet();
         public StatusToShow StatusToShow = ralcock.cbf.model.StatusToShow.ALL;
 
         public Config withSortOrder(final SortOrder sortOrder) {
@@ -48,6 +61,11 @@ public class BeerList {
             StylesToHide = stylesToHide;
             return this;
         }
+
+        public Config withAllergensToHide(Set<String> allergensToHide) {
+            AllergensToHide = allergensToHide;
+            return this;
+        }
     }
 
 
@@ -60,6 +78,7 @@ public class BeerList {
 
     private List<Beer> fBeerList;
     private Set<String> fFilterStyles;
+    private Set<String> fAllergensToHide;
     private Set<String> fStatusToHide;
 
     private static final Set<String> UNAVAILABLE_STATUS_SET;
@@ -79,12 +98,18 @@ public class BeerList {
         fSortOrder = config.SortOrder;
         fFilterText = config.SearchText;
         fFilterStyles = config.StylesToHide;
+        fAllergensToHide = config.AllergensToHide;
         fStatusToHide = statusToHide(config.StatusToShow);
         updateBeerList();
     }
 
     public void stylesToHide(final Set<String> stylesToShow) {
         fFilterStyles = stylesToShow;
+        updateBeerList();
+    }
+
+    public void allergensToHide(final Set<String> allergensToHide) {
+        fAllergensToHide = allergensToHide;
         updateBeerList();
     }
 
@@ -113,7 +138,7 @@ public class BeerList {
     }
 
     public void updateBeerList() {
-        fBeerList = buildList(fSortOrder, fFilterText, fFilterStyles, fStatusToHide);
+        fBeerList = buildList(fSortOrder, fFilterText, fFilterStyles, fAllergensToHide, fStatusToHide);
     }
 
     public int getCount() {
@@ -127,11 +152,12 @@ public class BeerList {
     private List<Beer> buildList(final SortOrder sortOrder,
                                  final CharSequence filterText,
                                  final Set<String> stylesToHide,
+                                 final Set<String> allergensToHide,
                                  final Set<String> statusToHide) {
         if (fType == Type.ALL)
-            return fBeers.allBeersList(sortOrder, filterText, stylesToHide, statusToHide);
+            return fBeers.allBeersList(sortOrder, filterText, stylesToHide, allergensToHide, statusToHide);
         else {
-            return fBeers.bookmarkedBeersList(sortOrder, filterText, stylesToHide, statusToHide);
+            return fBeers.bookmarkedBeersList(sortOrder, filterText, stylesToHide, allergensToHide, statusToHide);
         }
     }
 

--- a/libraries/beers/src/main/java/ralcock/cbf/model/BeerList.java
+++ b/libraries/beers/src/main/java/ralcock/cbf/model/BeerList.java
@@ -57,12 +57,12 @@ public class BeerList {
             return this;
         }
 
-        public Config withStylesToHide(Set<String> stylesToHide) {
+        public Config withStylesToHide(final Set<String> stylesToHide) {
             StylesToHide = stylesToHide;
             return this;
         }
 
-        public Config withAllergensToHide(Set<String> allergensToHide) {
+        public Config withAllergensToHide(final Set<String> allergensToHide) {
             AllergensToHide = allergensToHide;
             return this;
         }
@@ -113,12 +113,12 @@ public class BeerList {
         updateBeerList();
     }
 
-    public void filterBy(CharSequence filterText) {
+    public void filterBy(final CharSequence filterText) {
         fFilterText = filterText;
         updateBeerList();
     }
 
-    public void sortBy(SortOrder sortOrder) {
+    public void sortBy(final SortOrder sortOrder) {
         fSortOrder = sortOrder;
         updateBeerList();
     }

--- a/libraries/beers/src/main/java/ralcock/cbf/model/JsonBeerList.java
+++ b/libraries/beers/src/main/java/ralcock/cbf/model/JsonBeerList.java
@@ -79,12 +79,34 @@ public class JsonBeerList implements Iterable<Beer> {
         Iterator<String> keys = allergensObj.keys();
         while (keys.hasNext()) {
             String allergen = keys.next();
-            if (allergensList.length() > 0) {
-                allergensList.append(", ");
+            // Only include allergens with truthy values (1, true, non-empty string)
+            // API sends empty string "" for allergens not present
+            Object value = allergensObj.get(allergen);
+            if (isTruthyAllergenValue(value)) {
+                if (allergensList.length() > 0) {
+                    allergensList.append(", ");
+                }
+                allergensList.append(allergen);
             }
-            allergensList.append(allergen);
         }
         return allergensList.toString();
+    }
+
+    private boolean isTruthyAllergenValue(final Object value) {
+        if (value == null) {
+            return false;
+        }
+        if (value instanceof Number) {
+            return ((Number) value).intValue() != 0;
+        }
+        if (value instanceof Boolean) {
+            return (Boolean) value;
+        }
+        if (value instanceof String) {
+            String str = (String) value;
+            return !str.isEmpty() && !"0".equals(str) && !"false".equalsIgnoreCase(str);
+        }
+        return true;
     }
 
     private Brewery makeBrewery(final JSONObject producer) throws JSONException {

--- a/libraries/beers/src/main/java/ralcock/cbf/model/JsonBeerList.java
+++ b/libraries/beers/src/main/java/ralcock/cbf/model/JsonBeerList.java
@@ -22,7 +22,7 @@ public class JsonBeerList implements Iterable<Beer> {
     private static final String IDENTIFIER = "id";
     private static final String DISPENSE = "dispense";
     private static final String BAR = "bar";
-    private static final String ALLERGENS = "allegens";
+    private static final String ALLERGENS = "allergens";
 
     private List<Beer> fBeerList;
 
@@ -63,7 +63,28 @@ public class JsonBeerList implements Iterable<Beer> {
             .withStyle(product.isNull(STYLE)   ? "Unknown" : product.getString(STYLE))
             .withStatus(product.isNull(STATUS) ? "Unknown" : product.getString(STATUS))
             .withDispenseMethod(product.isNull(DISPENSE) ? "" : product.getString(DISPENSE))
+            .withAllergens(parseAllergens(product))
             .build();
+    }
+
+    private String parseAllergens(final JSONObject product) throws JSONException {
+        if (product.isNull(ALLERGENS)) {
+            return "";
+        }
+        JSONObject allergensObj = product.getJSONObject(ALLERGENS);
+        if (allergensObj.length() == 0) {
+            return "";
+        }
+        StringBuilder allergensList = new StringBuilder();
+        Iterator<String> keys = allergensObj.keys();
+        while (keys.hasNext()) {
+            String allergen = keys.next();
+            if (allergensList.length() > 0) {
+                allergensList.append(", ");
+            }
+            allergensList.append(allergen);
+        }
+        return allergensList.toString();
     }
 
     private Brewery makeBrewery(final JSONObject producer) throws JSONException {

--- a/libraries/beers/src/main/java/ralcock/cbf/model/dao/Beers.java
+++ b/libraries/beers/src/main/java/ralcock/cbf/model/dao/Beers.java
@@ -18,11 +18,13 @@ public interface Beers extends Dao<Beer, Long> {
     List<Beer> allBeersList(SortOrder sortOrder,
                             CharSequence filterText,
                             Set<String> filterStyles,
+                            Set<String> allergensToHide,
                             Set<String> statusToHide);
 
     List<Beer> bookmarkedBeersList(SortOrder sortOrder,
                                    CharSequence filterText,
                                    Set<String> filterStyles,
+                                   Set<String> allergensToHide,
                                    Set<String> statusToHide);
 
     void updateFromFestivalOrCreate(Beer beer);

--- a/libraries/beers/src/main/java/ralcock/cbf/model/dao/BeersImpl.java
+++ b/libraries/beers/src/main/java/ralcock/cbf/model/dao/BeersImpl.java
@@ -117,11 +117,11 @@ public class BeersImpl extends BaseDaoImpl<Beer, Long> implements Beers {
         }
     }
 
-    public void addBeerChangedListener(BeerChangedListener l) {
+    public void addBeerChangedListener(final BeerChangedListener l) {
         fListeners.add(l);
     }
 
-    public void removeBeerChangedListener(BeerChangedListener l) {
+    public void removeBeerChangedListener(final BeerChangedListener l) {
         fListeners.remove(l);
     }
 

--- a/libraries/beers/src/test/java/ralcock/cbf/model/BeerTest.java
+++ b/libraries/beers/src/test/java/ralcock/cbf/model/BeerTest.java
@@ -14,19 +14,20 @@ public class BeerTest
     private static final String STYLE = "IPA";
     private static final String STATUS = "Available";
     private static final String DISPENSE = "Cask";
+    private static final String ALLERGENS = "";
 
     private Brewery createTestBrewery() {
         return new Brewery("brew123", "Test Brewery", "A test brewery");
     }
 
     private Beer createTestBeer() {
-        return new Beer(FESTIVAL_ID, NAME, ABV, DESCRIPTION, STYLE, STATUS, DISPENSE, createTestBrewery());
+        return new Beer(FESTIVAL_ID, NAME, ABV, DESCRIPTION, STYLE, STATUS, DISPENSE, ALLERGENS, createTestBrewery());
     }
 
     @Test
     public void constructor() {
         Brewery brewery = createTestBrewery();
-        Beer beer = new Beer(FESTIVAL_ID, NAME, ABV, DESCRIPTION, STYLE, STATUS, DISPENSE, brewery);
+        Beer beer = new Beer(FESTIVAL_ID, NAME, ABV, DESCRIPTION, STYLE, STATUS, DISPENSE, ALLERGENS, brewery);
 
         assertThat(beer.getFestivalID(), equalTo(FESTIVAL_ID));
         assertThat(beer.getName(), equalTo(NAME));
@@ -35,6 +36,7 @@ public class BeerTest
         assertThat(beer.getStyle(), equalTo(STYLE));
         assertThat(beer.getStatus(), equalTo(STATUS));
         assertThat(beer.getDispenseMethod(), equalTo(DISPENSE));
+        assertThat(beer.getAllergens(), equalTo(ALLERGENS));
         assertThat(beer.getBrewery(), equalTo(brewery));
     }
 
@@ -76,8 +78,8 @@ public class BeerTest
 
     @Test
     public void equalsWithNullBrewery() {
-        Beer beer1 = new Beer(FESTIVAL_ID, NAME, ABV, DESCRIPTION, STYLE, STATUS, DISPENSE, null);
-        Beer beer2 = new Beer(FESTIVAL_ID, NAME, ABV, DESCRIPTION, STYLE, STATUS, DISPENSE, null);
+        Beer beer1 = new Beer(FESTIVAL_ID, NAME, ABV, DESCRIPTION, STYLE, STATUS, DISPENSE, ALLERGENS, null);
+        Beer beer2 = new Beer(FESTIVAL_ID, NAME, ABV, DESCRIPTION, STYLE, STATUS, DISPENSE, ALLERGENS, null);
         assertThat(beer1, equalTo(beer2));
     }
 
@@ -85,22 +87,22 @@ public class BeerTest
     public void notEqualsWithDifferentBrewery() {
         Brewery brewery1 = new Brewery("brew1", "Brewery 1", "Description 1");
         Brewery brewery2 = new Brewery("brew2", "Brewery 2", "Description 2");
-        Beer beer1 = new Beer(FESTIVAL_ID, NAME, ABV, DESCRIPTION, STYLE, STATUS, DISPENSE, brewery1);
-        Beer beer2 = new Beer(FESTIVAL_ID, NAME, ABV, DESCRIPTION, STYLE, STATUS, DISPENSE, brewery2);
+        Beer beer1 = new Beer(FESTIVAL_ID, NAME, ABV, DESCRIPTION, STYLE, STATUS, DISPENSE, ALLERGENS, brewery1);
+        Beer beer2 = new Beer(FESTIVAL_ID, NAME, ABV, DESCRIPTION, STYLE, STATUS, DISPENSE, ALLERGENS, brewery2);
         assertThat(beer1, not(equalTo(beer2)));
     }
 
     @Test
     public void notEqualsWithDifferentName() {
-        Beer beer1 = new Beer(FESTIVAL_ID, "Beer A", ABV, DESCRIPTION, STYLE, STATUS, DISPENSE, createTestBrewery());
-        Beer beer2 = new Beer(FESTIVAL_ID, "Beer B", ABV, DESCRIPTION, STYLE, STATUS, DISPENSE, createTestBrewery());
+        Beer beer1 = new Beer(FESTIVAL_ID, "Beer A", ABV, DESCRIPTION, STYLE, STATUS, DISPENSE, ALLERGENS, createTestBrewery());
+        Beer beer2 = new Beer(FESTIVAL_ID, "Beer B", ABV, DESCRIPTION, STYLE, STATUS, DISPENSE, ALLERGENS, createTestBrewery());
         assertThat(beer1, not(equalTo(beer2)));
     }
 
     @Test
     public void notEqualsWithDifferentAbv() {
-        Beer beer1 = new Beer(FESTIVAL_ID, NAME, 4.5f, DESCRIPTION, STYLE, STATUS, DISPENSE, createTestBrewery());
-        Beer beer2 = new Beer(FESTIVAL_ID, NAME, 6.5f, DESCRIPTION, STYLE, STATUS, DISPENSE, createTestBrewery());
+        Beer beer1 = new Beer(FESTIVAL_ID, NAME, 4.5f, DESCRIPTION, STYLE, STATUS, DISPENSE, ALLERGENS, createTestBrewery());
+        Beer beer2 = new Beer(FESTIVAL_ID, NAME, 6.5f, DESCRIPTION, STYLE, STATUS, DISPENSE, ALLERGENS, createTestBrewery());
         assertThat(beer1, not(equalTo(beer2)));
     }
 

--- a/libraries/beers/src/test/java/ralcock/cbf/model/dao/BeersImplTest.java
+++ b/libraries/beers/src/test/java/ralcock/cbf/model/dao/BeersImplTest.java
@@ -25,7 +25,7 @@ public class BeersImplTest {
 
     private static Beer aBeer() {
         return new  Beer("festivalId", "name", 4.2f,
-                         "description", "style", "status", "cask", aBrewery());
+                         "description", "style", "status", "cask", "", aBrewery());
     }
 
     @Before


### PR DESCRIPTION
Display allergen info in list and details views with UK FSA abbreviations. Users can filter beers by allergen to hide items containing specific allergens (gluten, sulphites, etc.).

- Add allergens field to Beer model with DB support
- Parse allergens from JSON API format {"gluten": 1, "sulphites": 1}
- Display allergen abbreviations (G, Su) in list items
- Show full allergen text in details view
- Add AllergenHelper for consistent allergen display
- Add "Filter by allergen" menu option and dialog
- Fix typo in JSON field name ("allegens" -> "allergens")
- Update BeersImpl to persist allergens on update
- Increment DB version to 33 for schema change

fixes #8 