### PR TITLE
Add Cambridge winter beer festival support

### DIFF
--- a/app/src/androidTest/java/ralcock/cbf/actions/BeerExporterTest.java
+++ b/app/src/androidTest/java/ralcock/cbf/actions/BeerExporterTest.java
@@ -10,6 +10,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import ralcock.cbf.R;
 import ralcock.cbf.model.Beer;
 import ralcock.cbf.model.StarRating;
 
@@ -80,7 +81,8 @@ public class BeerExporterTest {
         String subject = intent.getStringExtra(Intent.EXTRA_SUBJECT);
         assertNotNull("Intent should have EXTRA_SUBJECT", subject);
         assertTrue("Subject should contain 'Beers from'", subject.startsWith("Beers from "));
-        assertTrue("Subject should contain festival name", subject.contains("Cambridge Beer Festival"));
+        String festivalName = context.getString(R.string.festival_name);
+        assertTrue("Subject should contain festival name", subject.contains(festivalName));
     }
 
     @Test

--- a/app/src/androidTest/java/ralcock/cbf/model/BeerListTest.java
+++ b/app/src/androidTest/java/ralcock/cbf/model/BeerListTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertEquals;
 public class BeerListTest {
 
     private static final Set<String> EMPTY_SET = Collections.emptySet();
+    private static final String LOW_NO_CATEGORY = "low-no";
 
     private Beers fBeers;
     private Breweries fBreweries;
@@ -51,7 +52,8 @@ public class BeerListTest {
                 eq(mild),
                 eq(EMPTY_SET),
                 eq(EMPTY_SET),
-                eq(EMPTY_SET)
+                eq(EMPTY_SET),
+                eq(LOW_NO_CATEGORY)
         )).andReturn(Arrays.asList(aMild));
 
         expect(fBeers.allBeersList(
@@ -59,7 +61,8 @@ public class BeerListTest {
                 eq(best),
                 eq(EMPTY_SET),
                 eq(EMPTY_SET),
-                eq(EMPTY_SET)
+                eq(EMPTY_SET),
+                eq(LOW_NO_CATEGORY)
         )).andReturn(Arrays.asList(aBest, anotherBest));
 
         replay(fBeers, fBreweries);
@@ -92,7 +95,8 @@ public class BeerListTest {
                 eq(filterText),
                 eq(EMPTY_SET),
                 eq(EMPTY_SET),
-                eq(EMPTY_SET)
+                eq(EMPTY_SET),
+                eq(LOW_NO_CATEGORY)
         )).andReturn(Arrays.asList(beer1, beer2, beer3));
 
         final SortOrder sortOrder2 = SortOrder.BREWERY_NAME_DESC;
@@ -101,7 +105,8 @@ public class BeerListTest {
                 eq(filterText),
                 eq(EMPTY_SET),
                 eq(EMPTY_SET),
-                eq(EMPTY_SET)
+                eq(EMPTY_SET),
+                eq(LOW_NO_CATEGORY)
         )).andReturn(Arrays.asList(beer2, beer1, beer3));
         replay(fBeers, fBreweries);
 
@@ -135,7 +140,8 @@ public class BeerListTest {
                 eq(filterText),
                 eq(stylesToHide),
                 eq(EMPTY_SET),
-                eq(EMPTY_SET)
+                eq(EMPTY_SET),
+                eq(LOW_NO_CATEGORY)
         )).andReturn(Arrays.asList(new Beer()));
         replay(fBeers, fBreweries);
 

--- a/app/src/androidTest/java/ralcock/cbf/model/dao/BeersImplTest.java
+++ b/app/src/androidTest/java/ralcock/cbf/model/dao/BeersImplTest.java
@@ -59,13 +59,13 @@ public class BeersImplTest {
         Brewery brewery2 = new Brewery("2", "Best Brewery", "");
         fBreweries.create(brewery2);
 
-        fBeer1 = new Beer("1", "A Mild", 1f, "description1", fStyle1, "status1", "cask", "gluten", brewery);
+        fBeer1 = new Beer("1", "A Mild", 1f, "description1", fStyle1, "status1", "cask", "gluten", "beer", brewery);
         fBeers.create(fBeer1);
 
-        fBeer2 = new Beer("2", "A Best Bitter", 2f, "description2", fStyle2, "status2", "cask", "", brewery);
+        fBeer2 = new Beer("2", "A Best Bitter", 2f, "description2", fStyle2, "status2", "cask", "", "beer", brewery);
         fBeers.create(fBeer2);
 
-        fBeer3 = new Beer("3", "A Stout", 3f, "description3", fStyle2, "status3", "cask", "sulphites", brewery2);
+        fBeer3 = new Beer("3", "A Stout", 3f, "description3", fStyle2, "status3", "cask", "sulphites", "beer", brewery2);
         fBeers.create(fBeer3);
 
         assertEquals(3, fBeers.getNumberOfBeers());

--- a/app/src/androidTest/java/ralcock/cbf/model/dao/BeersImplTest.java
+++ b/app/src/androidTest/java/ralcock/cbf/model/dao/BeersImplTest.java
@@ -84,7 +84,7 @@ public class BeersImplTest {
     private List<Beer> doQuery(final SortOrder sortOrder, final CharSequence filterText, final Set<String> stylesToHide) throws SQLException {
         Set<String> noAllergensToHide = Collections.emptySet();
         Set<String> noStatusToHide = Collections.emptySet();
-        return fBeers.allBeersList(sortOrder, filterText, stylesToHide, noAllergensToHide, noStatusToHide);
+        return fBeers.allBeersList(sortOrder, filterText, stylesToHide, noAllergensToHide, noStatusToHide, null);
     }
 
     @Test

--- a/app/src/main/java/ralcock/cbf/CamBeerFestApplication.java
+++ b/app/src/main/java/ralcock/cbf/CamBeerFestApplication.java
@@ -318,8 +318,9 @@ public class CamBeerFestApplication extends AppCompatActivity {
     }
 
     private void showFilterByAllergenDialog() {
+        final Set<String> allAllergens = getBeerDao().getAvailableAllergens();
         final Set<String> allergensToHide = fAppPreferences.getAllergensToHide();
-        FilterByAllergenDialogFragment newFragment = FilterByAllergenDialogFragment.newInstance(allergensToHide);
+        FilterByAllergenDialogFragment newFragment = FilterByAllergenDialogFragment.newInstance(allergensToHide, allAllergens);
         newFragment.show(getSupportFragmentManager(), "filterByAllergen");
     }
 

--- a/app/src/main/java/ralcock/cbf/model/BeerDatabaseHelper.java
+++ b/app/src/main/java/ralcock/cbf/model/BeerDatabaseHelper.java
@@ -16,7 +16,7 @@ import java.sql.SQLException;
 public final class BeerDatabaseHelper extends OrmLiteSqliteOpenHelper {
     public static final String DATABASE_NAME = "BEERS";
 
-    private static final int DB_VERSION = 33; // allergens support
+    private static final int DB_VERSION = 34; // category support for winter festival
 
     private Breweries fBreweries;
     private Beers fBeers;

--- a/app/src/main/java/ralcock/cbf/service/MultiUrlInputStream.java
+++ b/app/src/main/java/ralcock/cbf/service/MultiUrlInputStream.java
@@ -63,16 +63,17 @@ public class MultiUrlInputStream extends InputStream {
     }
 
     private static String readEntireStream(final InputStream inputStream) throws IOException {
-        Reader reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
         StringBuilder builder = new StringBuilder();
         final char[] buffer = new char[0x10000];
         int read;
-        do {
-            read = reader.read(buffer);
-            if (read > 0) {
-                builder.append(buffer, 0, read);
-            }
-        } while (read >= 0);
+        try (Reader reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8)) {
+            do {
+                read = reader.read(buffer);
+                if (read > 0) {
+                    builder.append(buffer, 0, read);
+                }
+            } while (read >= 0);
+        }
         return builder.toString();
     }
 

--- a/app/src/main/java/ralcock/cbf/service/MultiUrlInputStream.java
+++ b/app/src/main/java/ralcock/cbf/service/MultiUrlInputStream.java
@@ -31,11 +31,18 @@ public class MultiUrlInputStream extends InputStream {
             try {
                 Log.i(TAG, "Fetching from: " + urlString);
                 URL url = new URL(urlString);
-                InputStream inputStream = url.openStream();
-                String jsonString = readEntireStream(inputStream);
-                inputStream.close();
+                try (InputStream inputStream = url.openStream()) {
+                    String jsonString = readEntireStream(inputStream);
 
-                JSONObject json = new JSONObject(jsonString);
+                    JSONObject json = new JSONObject(jsonString);
+                    if (json.has(PRODUCERS)) {
+                        JSONArray producers = json.getJSONArray(PRODUCERS);
+                        for (int i = 0; i < producers.length(); i++) {
+                            combinedProducers.put(producers.get(i));
+                        }
+                        Log.i(TAG, "Added " + producers.length() + " producers from " + urlString);
+                    }
+                }
                 if (json.has(PRODUCERS)) {
                     JSONArray producers = json.getJSONArray(PRODUCERS);
                     for (int i = 0; i < producers.length(); i++) {

--- a/app/src/main/java/ralcock/cbf/service/MultiUrlInputStream.java
+++ b/app/src/main/java/ralcock/cbf/service/MultiUrlInputStream.java
@@ -1,0 +1,103 @@
+package ralcock.cbf.service;
+
+import android.util.Log;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * InputStream that combines JSON beer lists from multiple URLs into a single stream.
+ * Each URL should return a JSON object with a "producers" array.
+ * The combined result merges all producers into a single JSON object.
+ */
+public class MultiUrlInputStream extends InputStream {
+    private static final String TAG = MultiUrlInputStream.class.getName();
+    private static final String PRODUCERS = "producers";
+
+    private final ByteArrayInputStream fCombinedStream;
+
+    public MultiUrlInputStream(final String[] urls) throws IOException {
+        JSONArray combinedProducers = new JSONArray();
+
+        for (String urlString : urls) {
+            try {
+                Log.i(TAG, "Fetching from: " + urlString);
+                URL url = new URL(urlString);
+                InputStream inputStream = url.openStream();
+                String jsonString = readEntireStream(inputStream);
+                inputStream.close();
+
+                JSONObject json = new JSONObject(jsonString);
+                if (json.has(PRODUCERS)) {
+                    JSONArray producers = json.getJSONArray(PRODUCERS);
+                    for (int i = 0; i < producers.length(); i++) {
+                        combinedProducers.put(producers.get(i));
+                    }
+                    Log.i(TAG, "Added " + producers.length() + " producers from " + urlString);
+                }
+            } catch (JSONException e) {
+                Log.w(TAG, "Failed to parse JSON from " + urlString, e);
+            } catch (IOException e) {
+                Log.w(TAG, "Failed to fetch from " + urlString + ", continuing with other URLs", e);
+            }
+        }
+
+        JSONObject combinedJson = new JSONObject();
+        try {
+            combinedJson.put(PRODUCERS, combinedProducers);
+        } catch (JSONException e) {
+            throw new IOException("Failed to create combined JSON", e);
+        }
+
+        byte[] bytes = combinedJson.toString().getBytes(StandardCharsets.UTF_8);
+        fCombinedStream = new ByteArrayInputStream(bytes);
+        Log.i(TAG, "Combined " + combinedProducers.length() + " total producers");
+    }
+
+    private static String readEntireStream(final InputStream inputStream) throws IOException {
+        Reader reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
+        StringBuilder builder = new StringBuilder();
+        final char[] buffer = new char[0x10000];
+        int read;
+        do {
+            read = reader.read(buffer);
+            if (read > 0) {
+                builder.append(buffer, 0, read);
+            }
+        } while (read >= 0);
+        return builder.toString();
+    }
+
+    @Override
+    public int read() throws IOException {
+        return fCombinedStream.read();
+    }
+
+    @Override
+    public int read(final byte[] b) throws IOException {
+        return fCombinedStream.read(b);
+    }
+
+    @Override
+    public int read(final byte[] b, final int off, final int len) throws IOException {
+        return fCombinedStream.read(b, off, len);
+    }
+
+    @Override
+    public int available() throws IOException {
+        return fCombinedStream.available();
+    }
+
+    @Override
+    public void close() throws IOException {
+        fCombinedStream.close();
+    }
+}

--- a/app/src/main/java/ralcock/cbf/service/MultiUrlInputStream.java
+++ b/app/src/main/java/ralcock/cbf/service/MultiUrlInputStream.java
@@ -43,13 +43,6 @@ public class MultiUrlInputStream extends InputStream {
                         Log.i(TAG, "Added " + producers.length() + " producers from " + urlString);
                     }
                 }
-                if (json.has(PRODUCERS)) {
-                    JSONArray producers = json.getJSONArray(PRODUCERS);
-                    for (int i = 0; i < producers.length(); i++) {
-                        combinedProducers.put(producers.get(i));
-                    }
-                    Log.i(TAG, "Added " + producers.length() + " producers from " + urlString);
-                }
             } catch (JSONException e) {
                 Log.w(TAG, "Failed to parse JSON from " + urlString, e);
             } catch (IOException e) {

--- a/app/src/main/java/ralcock/cbf/service/UpdateService.java
+++ b/app/src/main/java/ralcock/cbf/service/UpdateService.java
@@ -123,9 +123,8 @@ public class UpdateService extends OrmLiteBaseService<BeerDatabaseHelper> {
 
             @Override
             InputStream openStream() throws IOException {
-                String beerJsonURL = getString(R.string.beer_list_url);
-                URL url = new URL(beerJsonURL);
-                return url.openStream();
+                String[] beerListUrls = getResources().getStringArray(R.array.beer_list_urls);
+                return new MultiUrlInputStream(beerListUrls);
             }
 
             @Override

--- a/app/src/main/java/ralcock/cbf/view/BeerListFragmentPagerAdapter.java
+++ b/app/src/main/java/ralcock/cbf/view/BeerListFragmentPagerAdapter.java
@@ -8,7 +8,7 @@ import android.content.Context;
 
 public class BeerListFragmentPagerAdapter extends FragmentPagerAdapter {
     private static final String TAG = BeerListFragmentPagerAdapter.class.getName();
-    private final String tabTitles[] = new String[] { "All Beers", "Bookmarks" };
+    private final String tabTitles[] = new String[] { "Beer", "Low/No", "Bookmarks" };
     // private Context context;
 
     public BeerListFragmentPagerAdapter(FragmentManager fm, Context context) {
@@ -18,16 +18,21 @@ public class BeerListFragmentPagerAdapter extends FragmentPagerAdapter {
 
     @Override
     public int getCount() {
-        return 2;
+        return 3;
     }
 
     @Override
     public Fragment getItem(int position) {
         Log.i(TAG, "Returning new BeerListFragment for position " + position);
-        if (position == 0) {
-            return new AllBeersListFragment();
-        } else {
-            return new BookmarkedBeerListFragment();
+        switch (position) {
+            case 0:
+                return new AllBeersListFragment();
+            case 1:
+                return new LowNoAlcoholListFragment();
+            case 2:
+                return new BookmarkedBeerListFragment();
+            default:
+                return new AllBeersListFragment();
         }
     }
 

--- a/app/src/main/java/ralcock/cbf/view/BeerListFragmentPagerAdapter.java
+++ b/app/src/main/java/ralcock/cbf/view/BeerListFragmentPagerAdapter.java
@@ -5,15 +5,19 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentPagerAdapter;
 import android.content.Context;
+import ralcock.cbf.R;
 
 public class BeerListFragmentPagerAdapter extends FragmentPagerAdapter {
     private static final String TAG = BeerListFragmentPagerAdapter.class.getName();
-    private final String tabTitles[] = new String[] { "Beer", "Low/No", "Bookmarks" };
-    // private Context context;
+    private final String tabTitles[];
 
     public BeerListFragmentPagerAdapter(FragmentManager fm, Context context) {
         super(fm);
-        // this.context = context;
+        tabTitles = new String[] {
+            context.getString(R.string.tab_beer),
+            context.getString(R.string.tab_low_no),
+            context.getString(R.string.tab_bookmarks)
+        };
     }
 
     @Override

--- a/app/src/main/java/ralcock/cbf/view/FilterByAllergenDialogFragment.java
+++ b/app/src/main/java/ralcock/cbf/view/FilterByAllergenDialogFragment.java
@@ -21,10 +21,12 @@ import java.util.Set;
  */
 public class FilterByAllergenDialogFragment extends DialogFragment {
 
-    public static FilterByAllergenDialogFragment newInstance(final Set<String> allergensToHide) {
+    public static FilterByAllergenDialogFragment newInstance(final Set<String> allergensToHide,
+            final Set<String> allAllergens) {
         FilterByAllergenDialogFragment fragment = new FilterByAllergenDialogFragment();
         Bundle args = new Bundle();
         putStringSet(args, "allergensToHide", allergensToHide);
+        putStringSet(args, "allAllergens", allAllergens);
         fragment.setArguments(args);
         return fragment;
     }
@@ -46,11 +48,9 @@ public class FilterByAllergenDialogFragment extends DialogFragment {
     @Override
     public Dialog onCreateDialog(final Bundle savedInstanceState) {
         Set<String> allergensToHide = getStringSet(getArguments(), "allergensToHide");
+        Set<String> allAllergensSet = getStringSet(getArguments(), "allAllergens");
 
-        // Get allergens actually present in the festival beers
-        CamBeerFestApplication app = (CamBeerFestApplication) requireActivity();
-        Set<String> availableAllergens = app.getBeerDao().getAvailableAllergens();
-        final String[] allAllergens = availableAllergens.toArray(new String[0]);
+        final String[] allAllergens = allAllergensSet.toArray(new String[0]);
         final boolean[] checkedItems = new boolean[allAllergens.length];
 
         // Mark currently hidden allergens as checked

--- a/app/src/main/java/ralcock/cbf/view/FilterByAllergenDialogFragment.java
+++ b/app/src/main/java/ralcock/cbf/view/FilterByAllergenDialogFragment.java
@@ -49,7 +49,7 @@ public class FilterByAllergenDialogFragment extends DialogFragment {
 
         // Get allergens actually present in the festival beers
         CamBeerFestApplication app = (CamBeerFestApplication) requireActivity();
-        Set<String> availableAllergens = app.getBeers().getAvailableAllergens();
+        Set<String> availableAllergens = app.getBeerDao().getAvailableAllergens();
         final String[] allAllergens = availableAllergens.toArray(new String[0]);
         final boolean[] checkedItems = new boolean[allAllergens.length];
 

--- a/app/src/main/java/ralcock/cbf/view/FilterByAllergenDialogFragment.java
+++ b/app/src/main/java/ralcock/cbf/view/FilterByAllergenDialogFragment.java
@@ -47,8 +47,10 @@ public class FilterByAllergenDialogFragment extends DialogFragment {
     public Dialog onCreateDialog(final Bundle savedInstanceState) {
         Set<String> allergensToHide = getStringSet(getArguments(), "allergensToHide");
 
-        // Get all known allergens
-        final String[] allAllergens = AllergenHelper.getFilterableAllergens();
+        // Get allergens actually present in the festival beers
+        CamBeerFestApplication app = (CamBeerFestApplication) requireActivity();
+        Set<String> availableAllergens = app.getBeers().getAvailableAllergens();
+        final String[] allAllergens = availableAllergens.toArray(new String[0]);
         final boolean[] checkedItems = new boolean[allAllergens.length];
 
         // Mark currently hidden allergens as checked

--- a/app/src/main/java/ralcock/cbf/view/LowNoAlcoholListFragment.java
+++ b/app/src/main/java/ralcock/cbf/view/LowNoAlcoholListFragment.java
@@ -1,0 +1,18 @@
+package ralcock.cbf.view;
+
+import ralcock.cbf.AppPreferences;
+import ralcock.cbf.model.BeerList;
+import ralcock.cbf.model.dao.Beers;
+
+public class LowNoAlcoholListFragment extends BeerListFragment {
+    public LowNoAlcoholListFragment() {
+        super();
+    }
+
+    @Override
+    BeerList makeBeerList(final Beers beers) {
+        AppPreferences preferences = new AppPreferences(this.getActivity());
+        return BeerList.lowNoAlcoholBeers(beers, preferences.getBeerListConfig());
+    }
+
+}

--- a/app/src/main/res/raw/ormlite_config.txt
+++ b/app/src/main/res/raw/ormlite_config.txt
@@ -54,6 +54,11 @@ fieldName=fDispense
 columnName=dispense
 # --field-end--
 # --field-start--
+fieldName=fCategory
+columnName=category
+indexName=beers_category_idx
+# --field-end--
+# --field-start--
 fieldName=fIsOnWishList
 columnName=on_wish_list
 indexName=beers_on_wish_list_idx

--- a/app/src/main/res/values/festival.xml
+++ b/app/src/main/res/values/festival.xml
@@ -7,6 +7,6 @@
     <string formatted="false" name="share_intent_text">Drinking %1$s %2$s</string>
     <string-array name="beer_list_urls">
         <item>https://data.cambridgebeerfestival.com/cbfw2025/beer.json</item>
-        <item>https://data.cambridgebeerfestival.com/cbfw2025/no_low.json</item>
+        <item>https://data.cambridgebeerfestival.com/cbfw2025/low-no.json</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values/festival.xml
+++ b/app/src/main/res/values/festival.xml
@@ -1,13 +1,13 @@
 <resources>
     <string name="app_name">Cambridge Beer Festival</string>
-    <string name="festival_name">Cambridge Beer Festival</string>
-    <string name="festival_hashtag">cbf</string>
+    <string name="festival_name">Cambridge Winter Beer Festival 2025</string>
+    <string name="festival_hashtag">cbfw2025</string>
     <string name="festival_website_url">https://www.cambridgebeerfestival.com/</string>
     <string formatted="false" name="share_intent_subject">Drinking a %1$s at the %2$s</string>
     <string formatted="false" name="share_intent_text">Drinking %1$s %2$s</string>
-    <string name="beer_list_url">https://data.cambridgebeerfestival.com/cbf2025/beer.json</string>
+    <string name="beer_list_url">https://data.cambridgebeerfestival.com/cbfw2025/beers.json</string>
     <string-array name="beer_list_urls">
-        <item>https://data.cambridgebeerfestival.com/cbf2025/beer.json</item>
-        <item>https://data.cambridgebeerfestival.com/cbfw2025/beer.json</item>
+        <item>https://data.cambridgebeerfestival.com/cbfw2025/beers.json</item>
+        <item>https://data.cambridgebeerfestival.com/cbfw2025/no_low.json</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values/festival.xml
+++ b/app/src/main/res/values/festival.xml
@@ -1,9 +1,13 @@
 <resources>
     <string name="app_name">Cambridge Beer Festival</string>
-    <string name="festival_name">Cambridge Beer Festival 2025</string>
-    <string name="festival_hashtag">cbf2025</string>
+    <string name="festival_name">Cambridge Beer Festival</string>
+    <string name="festival_hashtag">cbf</string>
     <string name="festival_website_url">https://www.cambridgebeerfestival.com/</string>
     <string formatted="false" name="share_intent_subject">Drinking a %1$s at the %2$s</string>
     <string formatted="false" name="share_intent_text">Drinking %1$s %2$s</string>
     <string name="beer_list_url">https://data.cambridgebeerfestival.com/cbf2025/beer.json</string>
+    <string-array name="beer_list_urls">
+        <item>https://data.cambridgebeerfestival.com/cbf2025/beer.json</item>
+        <item>https://data.cambridgebeerfestival.com/cbfw2025/beer.json</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/festival.xml
+++ b/app/src/main/res/values/festival.xml
@@ -5,7 +5,6 @@
     <string name="festival_website_url">https://www.cambridgebeerfestival.com/</string>
     <string formatted="false" name="share_intent_subject">Drinking a %1$s at the %2$s</string>
     <string formatted="false" name="share_intent_text">Drinking %1$s %2$s</string>
-    <string name="beer_list_url">https://data.cambridgebeerfestival.com/cbfw2025/beers.json</string>
     <string-array name="beer_list_urls">
         <item>https://data.cambridgebeerfestival.com/cbfw2025/beers.json</item>
         <item>https://data.cambridgebeerfestival.com/cbfw2025/no_low.json</item>

--- a/app/src/main/res/values/festival.xml
+++ b/app/src/main/res/values/festival.xml
@@ -6,7 +6,7 @@
     <string formatted="false" name="share_intent_subject">Drinking a %1$s at the %2$s</string>
     <string formatted="false" name="share_intent_text">Drinking %1$s %2$s</string>
     <string-array name="beer_list_urls">
-        <item>https://data.cambridgebeerfestival.com/cbfw2025/beers.json</item>
+        <item>https://data.cambridgebeerfestival.com/cbfw2025/beer.json</item>
         <item>https://data.cambridgebeerfestival.com/cbfw2025/no_low.json</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -52,6 +52,10 @@
     <string name="bookmark_title">Bookmark</string>
     <string name="unbookmark_title">Remove Bookmark</string>
 
+    <string name="tab_beer">Beer</string>
+    <string name="tab_low_no">Low/No</string>
+    <string name="tab_bookmarks">Bookmarks</string>
+
     <string-array name="navigation_list">
         <item>All Beers</item>
         <item>Available Only</item>

--- a/libraries/beers/src/main/java/ralcock/cbf/model/Beer.java
+++ b/libraries/beers/src/main/java/ralcock/cbf/model/Beer.java
@@ -19,6 +19,7 @@ public final class Beer implements Serializable {
     public static final String FESTIVAL_ID_FIELD = "festival_id";
     public static final String STYLE_FIELD = "style";
     public static final String DISPENSE_FIELD = "dispense";
+    public static final String CATEGORY_FIELD = "category";
 
     public static final String RATING_FIELD = "rating";
     public static final String ON_WISH_LIST_FIELD = "on_wish_list";
@@ -55,6 +56,9 @@ public final class Beer implements Serializable {
     @DatabaseField(columnName = DISPENSE_FIELD)
     private String fDispense;
 
+    @DatabaseField(columnName = CATEGORY_FIELD, index = true)
+    private String fCategory;
+
     @DatabaseField(columnName = ON_WISH_LIST_FIELD, index = true)
     private boolean fIsOnWishList;
 
@@ -77,6 +81,7 @@ public final class Beer implements Serializable {
                 final String status,
                 final String dispense,
                 final String allergens,
+                final String category,
                 final Brewery brewery) {
         fFestivalID = festivalId;
         fBrewery = brewery;
@@ -87,6 +92,7 @@ public final class Beer implements Serializable {
         fStatus = status;
         fDispense = dispense;
         fAllergens = allergens;
+        fCategory = category;
     }
 
     public String getFestivalID() {
@@ -185,6 +191,18 @@ public final class Beer implements Serializable {
         return lowerAllergens.contains(allergen.toLowerCase());
     }
 
+    public String getCategory() {
+        return fCategory;
+    }
+
+    public void setCategory(final String category) {
+        fCategory = category;
+    }
+
+    public boolean isLowOrNoAlcohol() {
+        return fAbv <= 0.5f;
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;
@@ -205,6 +223,7 @@ public final class Beer implements Serializable {
         if (fUserComments != null ? !fUserComments.equals(beer.fUserComments) : beer.fUserComments != null)
             return false;
         if (fAllergens != null ? !fAllergens.equals(beer.fAllergens) : beer.fAllergens != null) return false;
+        if (fCategory != null ? !fCategory.equals(beer.fCategory) : beer.fCategory != null) return false;
 
         return true;
     }
@@ -223,6 +242,7 @@ public final class Beer implements Serializable {
         result = 31 * result + (fIsOnWishList ? 1 : 0);
         result = 31 * result + (fUserComments != null ? fUserComments.hashCode() : 0);
         result = 31 * result + (fAllergens != null ? fAllergens.hashCode() : 0);
+        result = 31 * result + (fCategory != null ? fCategory.hashCode() : 0);
         return result;
     }
 
@@ -243,6 +263,7 @@ public final class Beer implements Serializable {
         sb.append(", fIsOnWishList=").append(fIsOnWishList);
         sb.append(", fUserComments='").append(fUserComments).append('\'');
         sb.append(", fAllergens='").append(fAllergens).append('\'');
+        sb.append(", fCategory='").append(fCategory).append('\'');
         sb.append('}');
         return sb.toString();
     }

--- a/libraries/beers/src/main/java/ralcock/cbf/model/Beer.java
+++ b/libraries/beers/src/main/java/ralcock/cbf/model/Beer.java
@@ -216,18 +216,6 @@ public final class Beer implements Serializable {
         fCategory = category;
     }
 
-    /**
-     * Determines if this beer is classified as low or no alcohol.
-     * <p>
-     * A beer is considered low or no alcohol if its ABV (Alcohol By Volume) is less than or equal to 0.5%.
-     * This threshold is used to identify beers that are suitable for those seeking minimal or no alcohol content.
-     *
-     * @return true if the beer's ABV is less than or equal to 0.5%, false otherwise
-     */
-    public boolean isLowOrNoAlcohol() {
-        return fAbv <= 0.5f;
-    }
-
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;

--- a/libraries/beers/src/main/java/ralcock/cbf/model/Beer.java
+++ b/libraries/beers/src/main/java/ralcock/cbf/model/Beer.java
@@ -191,14 +191,39 @@ public final class Beer implements Serializable {
         return lowerAllergens.contains(allergen.toLowerCase());
     }
 
+    /**
+     * Returns the category of this beer.
+     * <p>
+     * The category indicates the type of beer, such as "beer" for standard beers,
+     * or "low-no" for low or no alcohol beers. Other possible values may be defined
+     * by the festival or data source.
+     *
+     * @return the category string for this beer (e.g., "beer", "low-no")
+     */
     public String getCategory() {
         return fCategory;
     }
 
+    /**
+     * Sets the category for this beer.
+     * <p>
+     * Valid category values include "beer" for standard beers and "low-no" for low or no alcohol beers.
+     * Other values may be used as defined by the festival or data source.
+     *
+     * @param category the category string to set (e.g., "beer", "low-no")
+     */
     public void setCategory(final String category) {
         fCategory = category;
     }
 
+    /**
+     * Determines if this beer is classified as low or no alcohol.
+     * <p>
+     * A beer is considered low or no alcohol if its ABV (Alcohol By Volume) is less than or equal to 0.5%.
+     * This threshold is used to identify beers that are suitable for those seeking minimal or no alcohol content.
+     *
+     * @return true if the beer's ABV is less than or equal to 0.5%, false otherwise
+     */
     public boolean isLowOrNoAlcohol() {
         return fAbv <= 0.5f;
     }

--- a/libraries/beers/src/main/java/ralcock/cbf/model/BeerBuilder.java
+++ b/libraries/beers/src/main/java/ralcock/cbf/model/BeerBuilder.java
@@ -9,6 +9,7 @@ public class BeerBuilder {
     private String fStatus = "";
     private String fDispense = "";
     private String fAllergens = "";
+    private String fCategory = "beer";
     private Brewery fBrewery = null;
 
     public static BeerBuilder aBeer() {
@@ -55,13 +56,18 @@ public class BeerBuilder {
         return this;
     }
 
+    public BeerBuilder withCategory(String category) {
+        fCategory = category;
+        return this;
+    }
+
     public BeerBuilder fromBrewery(Brewery brewery) {
         fBrewery = brewery;
         return this;
     }
 
     public Beer build() {
-        return new Beer(fFestivalId, fName, fAbv, fDescription, fStyle, fStatus, fDispense, fAllergens, fBrewery);
+        return new Beer(fFestivalId, fName, fAbv, fDescription, fStyle, fStatus, fDispense, fAllergens, fCategory, fBrewery);
     }
 
     public BeerBuilder from(final BreweryBuilder breweryBuilder) {

--- a/libraries/beers/src/main/java/ralcock/cbf/model/BeerList.java
+++ b/libraries/beers/src/main/java/ralcock/cbf/model/BeerList.java
@@ -15,7 +15,7 @@ public class BeerList {
         LOW_NO
     }
 
-    private static final String LOW_NO_CATEGORY = "no_low";
+    private static final String LOW_NO_CATEGORY = "low-no";
 
     public static class Config {
         public Config() {

--- a/libraries/beers/src/main/java/ralcock/cbf/model/BeerList.java
+++ b/libraries/beers/src/main/java/ralcock/cbf/model/BeerList.java
@@ -11,8 +11,11 @@ public class BeerList {
 
     private static enum Type {
         ALL,
-        BOOKMARKS
+        BOOKMARKS,
+        LOW_NO
     }
+
+    private static final float LOW_NO_MAX_ABV = 0.5f;
 
     public static class Config {
         public Config() {
@@ -154,10 +157,15 @@ public class BeerList {
                                  final Set<String> stylesToHide,
                                  final Set<String> allergensToHide,
                                  final Set<String> statusToHide) {
-        if (fType == Type.ALL)
-            return fBeers.allBeersList(sortOrder, filterText, stylesToHide, allergensToHide, statusToHide);
-        else {
-            return fBeers.bookmarkedBeersList(sortOrder, filterText, stylesToHide, allergensToHide, statusToHide);
+        switch (fType) {
+            case ALL:
+                return fBeers.allBeersList(sortOrder, filterText, stylesToHide, allergensToHide, statusToHide);
+            case BOOKMARKS:
+                return fBeers.bookmarkedBeersList(sortOrder, filterText, stylesToHide, allergensToHide, statusToHide);
+            case LOW_NO:
+                return fBeers.lowNoAlcoholBeersList(sortOrder, filterText, stylesToHide, allergensToHide, statusToHide, LOW_NO_MAX_ABV);
+            default:
+                return fBeers.allBeersList(sortOrder, filterText, stylesToHide, allergensToHide, statusToHide);
         }
     }
 
@@ -169,6 +177,11 @@ public class BeerList {
     public static BeerList bookmarkedBeers(final Beers beers,
                                            final Config config) {
         return new BeerList(beers, Type.BOOKMARKS, config);
+    }
+
+    public static BeerList lowNoAlcoholBeers(final Beers beers,
+                                              final Config config) {
+        return new BeerList(beers, Type.LOW_NO, config);
     }
 
 }

--- a/libraries/beers/src/main/java/ralcock/cbf/model/BeerList.java
+++ b/libraries/beers/src/main/java/ralcock/cbf/model/BeerList.java
@@ -15,7 +15,7 @@ public class BeerList {
         LOW_NO
     }
 
-    private static final float LOW_NO_MAX_ABV = 0.5f;
+    private static final String LOW_NO_CATEGORY = "no_low";
 
     public static class Config {
         public Config() {
@@ -163,7 +163,7 @@ public class BeerList {
             case BOOKMARKS:
                 return fBeers.bookmarkedBeersList(sortOrder, filterText, stylesToHide, allergensToHide, statusToHide);
             case LOW_NO:
-                return fBeers.lowNoAlcoholBeersList(sortOrder, filterText, stylesToHide, allergensToHide, statusToHide, LOW_NO_MAX_ABV);
+                return fBeers.lowNoAlcoholBeersList(sortOrder, filterText, stylesToHide, allergensToHide, statusToHide, LOW_NO_CATEGORY);
             default:
                 return fBeers.allBeersList(sortOrder, filterText, stylesToHide, allergensToHide, statusToHide);
         }

--- a/libraries/beers/src/main/java/ralcock/cbf/model/BeerList.java
+++ b/libraries/beers/src/main/java/ralcock/cbf/model/BeerList.java
@@ -159,13 +159,13 @@ public class BeerList {
                                  final Set<String> statusToHide) {
         switch (fType) {
             case ALL:
-                return fBeers.allBeersList(sortOrder, filterText, stylesToHide, allergensToHide, statusToHide);
+                return fBeers.allBeersList(sortOrder, filterText, stylesToHide, allergensToHide, statusToHide, LOW_NO_CATEGORY);
             case BOOKMARKS:
                 return fBeers.bookmarkedBeersList(sortOrder, filterText, stylesToHide, allergensToHide, statusToHide);
             case LOW_NO:
                 return fBeers.lowNoAlcoholBeersList(sortOrder, filterText, stylesToHide, allergensToHide, statusToHide, LOW_NO_CATEGORY);
             default:
-                return fBeers.allBeersList(sortOrder, filterText, stylesToHide, allergensToHide, statusToHide);
+                return fBeers.allBeersList(sortOrder, filterText, stylesToHide, allergensToHide, statusToHide, LOW_NO_CATEGORY);
         }
     }
 

--- a/libraries/beers/src/main/java/ralcock/cbf/model/JsonBeerList.java
+++ b/libraries/beers/src/main/java/ralcock/cbf/model/JsonBeerList.java
@@ -23,6 +23,7 @@ public class JsonBeerList implements Iterable<Beer> {
     private static final String DISPENSE = "dispense";
     private static final String BAR = "bar";
     private static final String ALLERGENS = "allergens";
+    private static final String CATEGORY = "category";
 
     private List<Beer> fBeerList;
 
@@ -64,6 +65,7 @@ public class JsonBeerList implements Iterable<Beer> {
             .withStatus(product.isNull(STATUS) ? "Unknown" : product.getString(STATUS))
             .withDispenseMethod(product.isNull(DISPENSE) ? "" : product.getString(DISPENSE))
             .withAllergens(parseAllergens(product))
+            .withCategory(product.isNull(CATEGORY) ? "beer" : product.getString(CATEGORY))
             .build();
     }
 

--- a/libraries/beers/src/main/java/ralcock/cbf/model/dao/Beers.java
+++ b/libraries/beers/src/main/java/ralcock/cbf/model/dao/Beers.java
@@ -32,7 +32,7 @@ public interface Beers extends Dao<Beer, Long> {
                                      Set<String> filterStyles,
                                      Set<String> allergensToHide,
                                      Set<String> statusToHide,
-                                     float maxAbv);
+                                     String category);
 
     void updateFromFestivalOrCreate(Beer beer);
 

--- a/libraries/beers/src/main/java/ralcock/cbf/model/dao/Beers.java
+++ b/libraries/beers/src/main/java/ralcock/cbf/model/dao/Beers.java
@@ -39,6 +39,8 @@ public interface Beers extends Dao<Beer, Long> {
 
     Set<String> getAvailableStyles();
 
+    Set<String> getAvailableAllergens();
+
     List<Beer> getRatedBeers();
 
     void updateBeer(Beer beer);

--- a/libraries/beers/src/main/java/ralcock/cbf/model/dao/Beers.java
+++ b/libraries/beers/src/main/java/ralcock/cbf/model/dao/Beers.java
@@ -28,6 +28,20 @@ public interface Beers extends Dao<Beer, Long> {
                                    Set<String> allergensToHide,
                                    Set<String> statusToHide);
 
+    /**
+     * Returns a list of beers filtered by the specified low/no alcohol category.
+     * <p>
+     * This method retrieves beers that match the given category,
+     * applying additional filters for sort order, text search, styles, allergens, and status.
+     *
+     * @param sortOrder        the order in which to sort the beers
+     * @param filterText       text to filter beer names/descriptions
+     * @param filterStyles     set of beer styles to exclude from the results
+     * @param allergensToHide  set of allergens to exclude beers containing them
+     * @param statusToHide     set of beer statuses to exclude
+     * @param category         the category of beers to include (e.g., "low-no")
+     * @return a list of beers matching the specified category and filters
+     */
     List<Beer> lowNoAlcoholBeersList(SortOrder sortOrder,
                                      CharSequence filterText,
                                      Set<String> filterStyles,
@@ -39,6 +53,11 @@ public interface Beers extends Dao<Beer, Long> {
 
     Set<String> getAvailableStyles();
 
+    /**
+     * Returns a set of all unique allergens present in the beers currently available in the database.
+     *
+     * @return a set of allergen names (as strings); the set may be empty if no allergens are found
+     */
     Set<String> getAvailableAllergens();
 
     List<Beer> getRatedBeers();

--- a/libraries/beers/src/main/java/ralcock/cbf/model/dao/Beers.java
+++ b/libraries/beers/src/main/java/ralcock/cbf/model/dao/Beers.java
@@ -27,6 +27,13 @@ public interface Beers extends Dao<Beer, Long> {
                                    Set<String> allergensToHide,
                                    Set<String> statusToHide);
 
+    List<Beer> lowNoAlcoholBeersList(SortOrder sortOrder,
+                                     CharSequence filterText,
+                                     Set<String> filterStyles,
+                                     Set<String> allergensToHide,
+                                     Set<String> statusToHide,
+                                     float maxAbv);
+
     void updateFromFestivalOrCreate(Beer beer);
 
     Set<String> getAvailableStyles();

--- a/libraries/beers/src/main/java/ralcock/cbf/model/dao/Beers.java
+++ b/libraries/beers/src/main/java/ralcock/cbf/model/dao/Beers.java
@@ -19,7 +19,8 @@ public interface Beers extends Dao<Beer, Long> {
                             CharSequence filterText,
                             Set<String> filterStyles,
                             Set<String> allergensToHide,
-                            Set<String> statusToHide);
+                            Set<String> statusToHide,
+                            String categoryToExclude);
 
     List<Beer> bookmarkedBeersList(SortOrder sortOrder,
                                    CharSequence filterText,

--- a/libraries/beers/src/main/java/ralcock/cbf/model/dao/BeersImpl.java
+++ b/libraries/beers/src/main/java/ralcock/cbf/model/dao/BeersImpl.java
@@ -210,6 +210,22 @@ public class BeersImpl extends BaseDaoImpl<Beer, Long> implements Beers {
         }
     }
 
+    /**
+     * Returns a list of beers filtered by the specified low/no alcohol category.
+     * <p>
+     * This method retrieves beers that match the given category (e.g., "Low Alcohol" or "No Alcohol"),
+     * applying additional filters for sort order, text search, styles, allergens, and status.
+     * Unlike {@link #allBeersList}, which excludes a category, this method includes only beers
+     * in the specified category.
+     *
+     * @param sortOrder        the order in which to sort the beers
+     * @param filterText       text to filter beer names/descriptions
+     * @param stylesToHide     set of beer styles to exclude from the results
+     * @param allergensToHide  set of allergens to exclude beers containing them
+     * @param statusToHide     set of beer statuses to exclude
+     * @param category         the category of beers to include (e.g., "Low Alcohol", "No Alcohol")
+     * @return a list of beers matching the specified category and filters
+     */
     public List<Beer> lowNoAlcoholBeersList(final SortOrder sortOrder,
                                             final CharSequence filterText,
                                             final Set<String> stylesToHide,

--- a/libraries/beers/src/main/java/ralcock/cbf/model/dao/BeersImpl.java
+++ b/libraries/beers/src/main/java/ralcock/cbf/model/dao/BeersImpl.java
@@ -97,6 +97,17 @@ public class BeersImpl extends BaseDaoImpl<Beer, Long> implements Beers {
         }
     }
 
+    /**
+     * Returns a sorted set of unique allergen names found in the beer database.
+     * <p>
+     * This method queries all beers for their allergen information, which is stored as
+     * comma-separated strings (e.g., "Gluten, Sulphites"). It splits these strings,
+     * trims whitespace, capitalizes each allergen name, deduplicates, and sorts the results.
+     * <p>
+     * The returned set contains allergen names in title case, such as "Gluten" or "Sulphites".
+     *
+     * @return a sorted set of unique allergen names present in the beer database
+     */
     public Set<String> getAvailableAllergens() {
         QueryBuilder<Beer, Long> qb = queryBuilder();
         qb.selectColumns(Beer.ALLERGENS_FIELD);

--- a/libraries/beers/src/main/java/ralcock/cbf/model/dao/BeersImpl.java
+++ b/libraries/beers/src/main/java/ralcock/cbf/model/dao/BeersImpl.java
@@ -164,8 +164,8 @@ public class BeersImpl extends BaseDaoImpl<Beer, Long> implements Beers {
                                             final Set<String> stylesToHide,
                                             final Set<String> allergensToHide,
                                             final Set<String> statusToHide,
-                                            final float maxAbv) {
-        QueryBuilder<Beer, Long> query = buildLowNoAlcoholQuery(sortOrder, filterText, stylesToHide, statusToHide, maxAbv);
+                                            final String category) {
+        QueryBuilder<Beer, Long> query = buildLowNoAlcoholQuery(sortOrder, filterText, stylesToHide, statusToHide, category);
         try {
             List<Beer> beers = query.query();
             return filterByAllergens(beers, allergensToHide);
@@ -235,12 +235,12 @@ public class BeersImpl extends BaseDaoImpl<Beer, Long> implements Beers {
                                                             final CharSequence filterText,
                                                             final Set<String> stylesToHide,
                                                             final Set<String> statusToHide,
-                                                            final float maxAbv) {
+                                                            final String category) {
         QueryBuilder<Beer, Long> qb = queryBuilder();
         Where where = qb.where();
         try {
             doWhere(where, fBreweries, filterText, stylesToHide, statusToHide);
-            where.and().le(Beer.ABV_FIELD, maxAbv);
+            where.and().eq(Beer.CATEGORY_FIELD, category);
             qb.orderBy(sortOrder.columnName(), sortOrder.ascending());
             return qb;
         } catch (SQLException e) {

--- a/libraries/beers/src/main/java/ralcock/cbf/model/dao/BeersImpl.java
+++ b/libraries/beers/src/main/java/ralcock/cbf/model/dao/BeersImpl.java
@@ -97,6 +97,7 @@ public class BeersImpl extends BaseDaoImpl<Beer, Long> implements Beers {
         }
     }
 
+    @Override
     /**
      * Returns a sorted set of unique allergen names found in the beer database.
      * <p>

--- a/libraries/beers/src/main/java/ralcock/cbf/model/dao/BeersImpl.java
+++ b/libraries/beers/src/main/java/ralcock/cbf/model/dao/BeersImpl.java
@@ -135,8 +135,9 @@ public class BeersImpl extends BaseDaoImpl<Beer, Long> implements Beers {
                                    final CharSequence filterText,
                                    final Set<String> stylesToHide,
                                    final Set<String> allergensToHide,
-                                   final Set<String> statusToHide) {
-        QueryBuilder<Beer, Long> query = buildSortedFilteredBeerQuery(sortOrder, filterText, stylesToHide, statusToHide);
+                                   final Set<String> statusToHide,
+                                   final String categoryToExclude) {
+        QueryBuilder<Beer, Long> query = buildSortedFilteredBeerQuery(sortOrder, filterText, stylesToHide, statusToHide, categoryToExclude);
         try {
             List<Beer> beers = query.query();
             return filterByAllergens(beers, allergensToHide);
@@ -219,11 +220,15 @@ public class BeersImpl extends BaseDaoImpl<Beer, Long> implements Beers {
     private QueryBuilder<Beer, Long> buildSortedFilteredBeerQuery(final SortOrder sortOrder,
                                                                   final CharSequence filterText,
                                                                   final Set<String> stylesToHide,
-                                                                  final Set<String> statusToHide) {
+                                                                  final Set<String> statusToHide,
+                                                                  final String categoryToExclude) {
         QueryBuilder<Beer, Long> qb = queryBuilder();
         Where where = qb.where();
         try {
             doWhere(where, fBreweries, filterText, stylesToHide, statusToHide);
+            if (categoryToExclude != null && !categoryToExclude.isEmpty()) {
+                where.and().ne(Beer.CATEGORY_FIELD, categoryToExclude);
+            }
             qb.orderBy(sortOrder.columnName(), sortOrder.ascending());
             return qb;
         } catch (SQLException e) {

--- a/libraries/beers/src/main/java/ralcock/cbf/model/dao/BeersImpl.java
+++ b/libraries/beers/src/main/java/ralcock/cbf/model/dao/BeersImpl.java
@@ -211,6 +211,7 @@ public class BeersImpl extends BaseDaoImpl<Beer, Long> implements Beers {
         }
     }
 
+    @Override
     /**
      * Returns a list of beers filtered by the specified low/no alcohol category.
      * <p>

--- a/libraries/beers/src/main/java/ralcock/cbf/model/dao/BeersImpl.java
+++ b/libraries/beers/src/main/java/ralcock/cbf/model/dao/BeersImpl.java
@@ -97,7 +97,6 @@ public class BeersImpl extends BaseDaoImpl<Beer, Long> implements Beers {
         }
     }
 
-    @Override
     /**
      * Returns a sorted set of unique allergen names found in the beer database.
      * <p>
@@ -109,6 +108,7 @@ public class BeersImpl extends BaseDaoImpl<Beer, Long> implements Beers {
      *
      * @return a sorted set of unique allergen names present in the beer database
      */
+    @Override
     public Set<String> getAvailableAllergens() {
         QueryBuilder<Beer, Long> qb = queryBuilder();
         qb.selectColumns(Beer.ALLERGENS_FIELD);
@@ -128,7 +128,11 @@ public class BeersImpl extends BaseDaoImpl<Beer, Long> implements Beers {
                         String allergen = part.trim();
                         if (!allergen.isEmpty()) {
                             // Capitalize first letter
-                            allergen = allergen.substring(0, 1).toUpperCase() + allergen.substring(1).toLowerCase();
+                            if (allergen.length() == 1) {
+                                allergen = allergen.toUpperCase();
+                            } else {
+                                allergen = allergen.substring(0, 1).toUpperCase() + allergen.substring(1).toLowerCase();
+                            }
                             allergens.add(allergen);
                         }
                     }
@@ -211,11 +215,10 @@ public class BeersImpl extends BaseDaoImpl<Beer, Long> implements Beers {
         }
     }
 
-    @Override
     /**
      * Returns a list of beers filtered by the specified low/no alcohol category.
      * <p>
-     * This method retrieves beers that match the given category (e.g., "Low Alcohol" or "No Alcohol"),
+     * This method retrieves beers that match the given category (e.g., "low-no"),
      * applying additional filters for sort order, text search, styles, allergens, and status.
      * Unlike {@link #allBeersList}, which excludes a category, this method includes only beers
      * in the specified category.
@@ -225,9 +228,10 @@ public class BeersImpl extends BaseDaoImpl<Beer, Long> implements Beers {
      * @param stylesToHide     set of beer styles to exclude from the results
      * @param allergensToHide  set of allergens to exclude beers containing them
      * @param statusToHide     set of beer statuses to exclude
-     * @param category         the category of beers to include (e.g., "Low Alcohol", "No Alcohol")
+     * @param category         the category of beers to include (e.g., "low-no")
      * @return a list of beers matching the specified category and filters
      */
+    @Override
     public List<Beer> lowNoAlcoholBeersList(final SortOrder sortOrder,
                                             final CharSequence filterText,
                                             final Set<String> stylesToHide,

--- a/libraries/beers/src/main/java/ralcock/cbf/model/dao/BeersImpl.java
+++ b/libraries/beers/src/main/java/ralcock/cbf/model/dao/BeersImpl.java
@@ -216,7 +216,7 @@ public class BeersImpl extends BaseDaoImpl<Beer, Long> implements Beers {
     }
 
     /**
-     * Returns a list of beers filtered by the specified low/no alcohol category.
+     * Returns a list of beers filtered by the specified category from the database.
      * <p>
      * This method retrieves beers that match the given category (e.g., "low-no"),
      * applying additional filters for sort order, text search, styles, allergens, and status.

--- a/libraries/beers/src/test/java/ralcock/cbf/model/BeerTest.java
+++ b/libraries/beers/src/test/java/ralcock/cbf/model/BeerTest.java
@@ -15,19 +15,20 @@ public class BeerTest
     private static final String STATUS = "Available";
     private static final String DISPENSE = "Cask";
     private static final String ALLERGENS = "";
+    private static final String CATEGORY = "beer";
 
     private Brewery createTestBrewery() {
         return new Brewery("brew123", "Test Brewery", "A test brewery");
     }
 
     private Beer createTestBeer() {
-        return new Beer(FESTIVAL_ID, NAME, ABV, DESCRIPTION, STYLE, STATUS, DISPENSE, ALLERGENS, createTestBrewery());
+        return new Beer(FESTIVAL_ID, NAME, ABV, DESCRIPTION, STYLE, STATUS, DISPENSE, ALLERGENS, CATEGORY, createTestBrewery());
     }
 
     @Test
     public void constructor() {
         Brewery brewery = createTestBrewery();
-        Beer beer = new Beer(FESTIVAL_ID, NAME, ABV, DESCRIPTION, STYLE, STATUS, DISPENSE, ALLERGENS, brewery);
+        Beer beer = new Beer(FESTIVAL_ID, NAME, ABV, DESCRIPTION, STYLE, STATUS, DISPENSE, ALLERGENS, CATEGORY, brewery);
 
         assertThat(beer.getFestivalID(), equalTo(FESTIVAL_ID));
         assertThat(beer.getName(), equalTo(NAME));
@@ -37,6 +38,7 @@ public class BeerTest
         assertThat(beer.getStatus(), equalTo(STATUS));
         assertThat(beer.getDispenseMethod(), equalTo(DISPENSE));
         assertThat(beer.getAllergens(), equalTo(ALLERGENS));
+        assertThat(beer.getCategory(), equalTo(CATEGORY));
         assertThat(beer.getBrewery(), equalTo(brewery));
     }
 
@@ -78,8 +80,8 @@ public class BeerTest
 
     @Test
     public void equalsWithNullBrewery() {
-        Beer beer1 = new Beer(FESTIVAL_ID, NAME, ABV, DESCRIPTION, STYLE, STATUS, DISPENSE, ALLERGENS, null);
-        Beer beer2 = new Beer(FESTIVAL_ID, NAME, ABV, DESCRIPTION, STYLE, STATUS, DISPENSE, ALLERGENS, null);
+        Beer beer1 = new Beer(FESTIVAL_ID, NAME, ABV, DESCRIPTION, STYLE, STATUS, DISPENSE, ALLERGENS, CATEGORY, null);
+        Beer beer2 = new Beer(FESTIVAL_ID, NAME, ABV, DESCRIPTION, STYLE, STATUS, DISPENSE, ALLERGENS, CATEGORY, null);
         assertThat(beer1, equalTo(beer2));
     }
 
@@ -87,22 +89,22 @@ public class BeerTest
     public void notEqualsWithDifferentBrewery() {
         Brewery brewery1 = new Brewery("brew1", "Brewery 1", "Description 1");
         Brewery brewery2 = new Brewery("brew2", "Brewery 2", "Description 2");
-        Beer beer1 = new Beer(FESTIVAL_ID, NAME, ABV, DESCRIPTION, STYLE, STATUS, DISPENSE, ALLERGENS, brewery1);
-        Beer beer2 = new Beer(FESTIVAL_ID, NAME, ABV, DESCRIPTION, STYLE, STATUS, DISPENSE, ALLERGENS, brewery2);
+        Beer beer1 = new Beer(FESTIVAL_ID, NAME, ABV, DESCRIPTION, STYLE, STATUS, DISPENSE, ALLERGENS, CATEGORY, brewery1);
+        Beer beer2 = new Beer(FESTIVAL_ID, NAME, ABV, DESCRIPTION, STYLE, STATUS, DISPENSE, ALLERGENS, CATEGORY, brewery2);
         assertThat(beer1, not(equalTo(beer2)));
     }
 
     @Test
     public void notEqualsWithDifferentName() {
-        Beer beer1 = new Beer(FESTIVAL_ID, "Beer A", ABV, DESCRIPTION, STYLE, STATUS, DISPENSE, ALLERGENS, createTestBrewery());
-        Beer beer2 = new Beer(FESTIVAL_ID, "Beer B", ABV, DESCRIPTION, STYLE, STATUS, DISPENSE, ALLERGENS, createTestBrewery());
+        Beer beer1 = new Beer(FESTIVAL_ID, "Beer A", ABV, DESCRIPTION, STYLE, STATUS, DISPENSE, ALLERGENS, CATEGORY, createTestBrewery());
+        Beer beer2 = new Beer(FESTIVAL_ID, "Beer B", ABV, DESCRIPTION, STYLE, STATUS, DISPENSE, ALLERGENS, CATEGORY, createTestBrewery());
         assertThat(beer1, not(equalTo(beer2)));
     }
 
     @Test
     public void notEqualsWithDifferentAbv() {
-        Beer beer1 = new Beer(FESTIVAL_ID, NAME, 4.5f, DESCRIPTION, STYLE, STATUS, DISPENSE, ALLERGENS, createTestBrewery());
-        Beer beer2 = new Beer(FESTIVAL_ID, NAME, 6.5f, DESCRIPTION, STYLE, STATUS, DISPENSE, ALLERGENS, createTestBrewery());
+        Beer beer1 = new Beer(FESTIVAL_ID, NAME, 4.5f, DESCRIPTION, STYLE, STATUS, DISPENSE, ALLERGENS, CATEGORY, createTestBrewery());
+        Beer beer2 = new Beer(FESTIVAL_ID, NAME, 6.5f, DESCRIPTION, STYLE, STATUS, DISPENSE, ALLERGENS, CATEGORY, createTestBrewery());
         assertThat(beer1, not(equalTo(beer2)));
     }
 

--- a/libraries/beers/src/test/java/ralcock/cbf/model/dao/BeersImplTest.java
+++ b/libraries/beers/src/test/java/ralcock/cbf/model/dao/BeersImplTest.java
@@ -25,7 +25,7 @@ public class BeersImplTest {
 
     private static Beer aBeer() {
         return new  Beer("festivalId", "name", 4.2f,
-                         "description", "style", "status", "cask", "", aBrewery());
+                         "description", "style", "status", "cask", "", "beer", aBrewery());
     }
 
     @Before


### PR DESCRIPTION
- Add category field to Beer model for drink type classification
- Add Low/No alcohol tab (filters drinks with ABV <= 0.5%)
- Support fetching from multiple festival URLs (cbf2025 + cbfw2025)
- Update BeerListFragmentPagerAdapter for 3 tabs: Beer, Low/No, Bookmarks
- Create MultiUrlInputStream to combine JSON from multiple URLs
- Bump database version to 34 for category column support
- Fix tests to use updated Beer constructor with category parameter
- Update ormlite_config.txt with category field